### PR TITLE
Use name and type comparising when appending a dataframe into table

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,8 +1,10 @@
 Changelog
 =========
 
-0.2.0 / 2017-?
+0.2.0 / 2017-02-26
 --------------
+
+Fixed an issue with appending to a BigQuery table where fields have modes (NULLABLE,REQUIRED,REPEATED). The changes concern solely the comparision of the local (DataFrame) and remote (BQ) schema in GbqConnector.verify_schema function. The fix is to omit other field attributes than name and type.
 
 0.1.2 / 2017-02-23
 ------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 0.2.0 / 2017-02-26
 --------------
 
-Fixed an issue with appending to a BigQuery table where fields have modes (NULLABLE,REQUIRED,REPEATED). The changes concern solely the comparision of the local (DataFrame) and remote (BQ) schema in GbqConnector.verify_schema function. The fix is to omit other field attributes than name and type.
+Fixed an `issue <https://github.com/pydata/pandas-gbq/issues/13>` with appending to a BigQuery table where fields have modes (NULLABLE,REQUIRED,REPEATED). The changes concern solely the comparision of the local (DataFrame) and remote (BQ) schema in GbqConnector.verify_schema function. The fix is to omit other field attributes than name and type.
 
 0.1.2 / 2017-02-23
 ------------------

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -563,8 +563,12 @@ class GbqConnector(object):
                 datasetId=dataset_id,
                 tableId=table_id).execute()['schema']
 
+            remote_fields = [{'name': field_remote['name'],
+                              'type': field_remote['type']}
+                             for field_remote in remote_schema]
+
             fields_remote = set([json.dumps(field_remote)
-                                 for field_remote in remote_schema['fields']])
+                                 for field_remote in remote_fields])
             fields_local = set(json.dumps(field_local)
                                for field_local in schema['fields'])
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -565,7 +565,7 @@ class GbqConnector(object):
 
             remote_fields = [{'name': field_remote['name'],
                               'type': field_remote['type']}
-                             for field_remote in remote_schema]
+                             for field_remote in remote_schema['fields']]
 
             fields_remote = set([json.dumps(field_remote)
                                  for field_remote in remote_fields])

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1163,14 +1163,26 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(tm.TestCase):
 
     def test_verify_schema_ignores_field_mode(self):
         test_id = "14"
-        test_schema_1 = {'fields': [{'name': 'A', 'type': 'FLOAT', 'mode': 'NULLABLE'},
-                                    {'name': 'B', 'type': 'FLOAT', 'mode': 'NULLABLE'},
-                                    {'name': 'C', 'type': 'STRING', 'mode': 'NULLABLE'},
-                                    {'name': 'D', 'type': 'TIMESTAMP', 'mode': 'REQUIRED'}]}
-        test_schema_2 = {'fields': [{'name': 'A', 'type': 'FLOAT'},
-                                    {'name': 'B', 'type': 'FLOAT'},
-                                    {'name': 'C', 'type': 'STRING'},
-                                    {'name': 'D', 'type': 'TIMESTAMP'}]}
+        test_schema_1 = {'fields': [{'name': 'A',
+                                     'type': 'FLOAT',
+                                     'mode': 'NULLABLE'},
+                                    {'name': 'B',
+                                     'type': 'FLOAT',
+                                     'mode': 'NULLABLE'},
+                                    {'name': 'C',
+                                     'type': 'STRING',
+                                     'mode': 'NULLABLE'},
+                                    {'name': 'D',
+                                     'type': 'TIMESTAMP',
+                                     'mode': 'REQUIRED'}]}
+        test_schema_2 = {'fields': [{'name': 'A',
+                                     'type': 'FLOAT'},
+                                    {'name': 'B',
+                                     'type': 'FLOAT'},
+                                    {'name': 'C',
+                                     'type': 'STRING'},
+                                    {'name': 'D',
+                                     'type': 'TIMESTAMP'}]}
 
         self.table.create(TABLE_ID + test_id, test_schema_1)
         self.assertTrue(self.sut.verify_schema(

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1161,6 +1161,22 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(tm.TestCase):
                    _get_project_id(), if_exists='append',
                    private_key=_get_private_key_path())
 
+    def test_verify_schema_ignores_field_mode(self):
+        test_id = "14"
+        test_schema_1 = {'fields': [{'name': 'A', 'type': 'FLOAT', 'mode': 'NULLABLE'},
+                                    {'name': 'B', 'type': 'FLOAT', 'mode': 'NULLABLE'},
+                                    {'name': 'C', 'type': 'STRING', 'mode': 'NULLABLE'},
+                                    {'name': 'D', 'type': 'TIMESTAMP', 'mode': 'REQUIRED'}]}
+        test_schema_2 = {'fields': [{'name': 'A', 'type': 'FLOAT'},
+                                    {'name': 'B', 'type': 'FLOAT'},
+                                    {'name': 'C', 'type': 'STRING'},
+                                    {'name': 'D', 'type': 'TIMESTAMP'}]}
+
+        self.table.create(TABLE_ID + test_id, test_schema_1)
+        self.assertTrue(self.sut.verify_schema(
+            self.dataset_prefix + "1", TABLE_ID + test_id, test_schema_2),
+            'Expected schema to match')
+
     def test_list_dataset(self):
         dataset_id = self.dataset_prefix + "1"
         self.assertTrue(dataset_id in self.dataset.datasets(),


### PR DESCRIPTION
I modified GbqConnector.verify_schema function to parse name and type from the remote schema (basically dropping mode) and include those in the compared fields.

Currently, when appending to a BQ table, comparison between the destination table's schema and a dataframe schema is done over superset of a BQ schema definition (name, type, mode) when _generate_bq_schema parses only name and type from a dataframe.

IMO it would be inconvenient to make the mode check in the module by generating completeness of columns (includes null values or not). So raising a generic GBQ error is more convenient here.

closes #13