### PR TITLE
When appending to a table, load if the dataframe contains a subset of the existing schema

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,10 @@ Changelog
 
 - All gbq errors will simply be subclasses of ``ValueError`` and no longer inherit from the deprecated ``PandasError``.
 
+0.1.5 / 2017-04-20
+------------------
+- When using ```to_gbq``` if ```if_exists``` is set to ```append```, dataframe needs to contain only a subset of the fields in the BigQuery schema. GH#24
+
 0.1.4 / 2017-03-17
 ------------------
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Resolve issue where the optional ``--noauth_local_webserver`` command line argument would not be propagated during the authentication process. (:issue:`35`)
 - Drop support for Python 3.4 (:issue:`40`)
+- When using ```to_gbq``` if ```if_exists``` is set to ```append```, dataframe needs to contain only a subset of the fields in the BigQuery schema. (:issue: `24`)
+
 
 0.1.6 / 2017-05-03
 ------------------
@@ -13,10 +15,6 @@ Changelog
 - All gbq errors will simply be subclasses of ``ValueError`` and no longer inherit from the deprecated ``PandasError``.
 
 0.1.5 / 2017-04-20
-------------------
-- When using ```to_gbq``` if ```if_exists``` is set to ```append```, dataframe needs to contain only a subset of the fields in the BigQuery schema. GH#24
-
-0.1.4 / 2017-03-17
 ------------------
 
 - ``InvalidIndexColumn`` will be raised instead of ``InvalidColumnOrder`` in ``read_gbq`` when the index column specified does not exist in the BigQuery schema. (:issue:`6`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Resolve issue where the optional ``--noauth_local_webserver`` command line argument would not be propagated during the authentication process. (:issue:`35`)
 - Drop support for Python 3.4 (:issue:`40`)
-- When using ```to_gbq``` if ```if_exists``` is set to ```append```, dataframe needs to contain only a subset of the fields in the BigQuery schema. (:issue: `24`)
+- The dataframe passed to ```.to_gbq(...., if_exists='append')``` needs to contain only a subset of the fields in the BigQuery schema. To support this, ```schema_is_subset``` tests whether a local dataframe is a subset of the BigQuery schema and ```schema``` returns the remote schema. (:issue:`24`)
 
 
 0.1.6 / 2017-05-03

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Resolve issue where the optional ``--noauth_local_webserver`` command line argument would not be propagated during the authentication process. (:issue:`35`)
 - Drop support for Python 3.4 (:issue:`40`)
-- The dataframe passed to ```.to_gbq(...., if_exists='append')``` needs to contain only a subset of the fields in the BigQuery schema. To support this, ```schema_is_subset``` tests whether a local dataframe is a subset of the BigQuery schema and ```schema``` returns the remote schema. (:issue:`24`)
+- The dataframe passed to ```.to_gbq(...., if_exists='append')``` needs to contain only a subset of the fields in the BigQuery schema. (:issue:`24`)
 
 
 0.1.6 / 2017-05-03
@@ -14,7 +14,7 @@ Changelog
 
 - All gbq errors will simply be subclasses of ``ValueError`` and no longer inherit from the deprecated ``PandasError``.
 
-0.1.5 / 2017-04-20
+0.1.4 / 2017-03-17
 ------------------
 
 - ``InvalidIndexColumn`` will be raised instead of ``InvalidColumnOrder`` in ``read_gbq`` when the index column specified does not exist in the BigQuery schema. (:issue:`6`)

--- a/docs/source/writing.rst
+++ b/docs/source/writing.rst
@@ -40,7 +40,7 @@ a ``TableCreationError`` if the destination table already exists.
 
    If the ``if_exists`` argument is set to ``'append'``, the destination dataframe will
    be written to the table using the defined table schema and column types. The
-   dataframe must match the destination table in structure and data types.
+   dataframe must contain fields (matching name and type) currently in the destination.
    If the ``if_exists`` argument is set to ``'replace'``, and the existing table has a
    different schema, a delay of 2 minutes will be forced to ensure that the new schema
    has propagated in the Google environment. See

--- a/docs/source/writing.rst
+++ b/docs/source/writing.rst
@@ -40,7 +40,7 @@ a ``TableCreationError`` if the destination table already exists.
 
    If the ``if_exists`` argument is set to ``'append'``, the destination dataframe will
    be written to the table using the defined table schema and column types. The
-   dataframe must contain fields (matching name and type) currently in the destination.
+   dataframe must contain fields (matching name and type) currently in the destination table.
    If the ``if_exists`` argument is set to ``'replace'``, and the existing table has a
    different schema, a delay of 2 minutes will be forced to ensure that the new schema
    has propagated in the Google environment. See

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -557,7 +557,19 @@ class GbqConnector(object):
 
         self._print("\n")
 
-    def verify_schema(self, dataset_id, table_id, schema):
+    def schema(self, dataset_id, table_id):
+        """Retrieve the schema of the table
+
+        Obtain from BigQuery the field names and field types
+        for the table defined by the parameters
+
+        :param str dataset_id: Name of the BigQuery dataset for the table
+        :param str table_id: Name of the BigQuery table
+
+        :return: Fields representing the schema
+        :rtype: list of dicts
+        """
+
         try:
             from googleapiclient.errors import HttpError
         except:
@@ -573,14 +585,52 @@ class GbqConnector(object):
                               'type': field_remote['type']}
                              for field_remote in remote_schema['fields']]
 
-            fields_remote = set([json.dumps(field_remote)
-                                 for field_remote in remote_fields])
-            fields_local = set(json.dumps(field_local)
-                               for field_local in schema['fields'])
-
-            return fields_remote == fields_local
+            return remote_fields
         except HttpError as ex:
             self.process_http_error(ex)
+
+    def verify_schema(self, dataset_id, table_id, schema):
+        """Indicate whether schemas match exactly
+
+        Compare the BigQuery table identified in the parameters with
+        the schema passed in and indicate whether all fields in the former
+        are present in the latter. Order is not considered.
+
+        :param str dataset_id: Name of the BigQuery dataset for the table
+        :param str table_id: Name of the BigQuery table
+        :param list(dict) schema: Schema for comparison. Each item should have
+            a 'name' and a 'type'
+
+        :return: Whether the schemas match
+        :rtype: bool
+        """
+
+        fields_remote = sorted(self.schema(dataset_id, table_id),
+                               key=lambda x: x['name'])
+        fields_local = sorted(schema['fields'], key=lambda x: x['name'])
+
+        return fields_remote == fields_local
+
+    def schema_is_subset(self, dataset_id, table_id, schema):
+        """Indicate whether the schema to be uploaded is a subset
+
+        Compare the BigQuery table identified in the parameters with
+        the schema passed in and indicate whether a subset of the fields in
+        the former are present in the latter. Order is not considered.
+
+        :param str dataset_id: Name of the BigQuery dataset for the table
+        :param str table_id: Name of the BigQuery table
+        :param list(dict) schema: Schema for comparison. Each item should have
+            a 'name' and a 'type'
+
+        :return: Whether the passed schema is a subset
+        :rtype: bool
+        """
+
+        fields_remote = self.schema(dataset_id, table_id)
+        fields_local = schema['fields']
+
+        return all(field in fields_remote for field in fields_local)
 
     def delete_and_recreate_table(self, dataset_id, table_id, table_schema):
         delay = 0
@@ -844,7 +894,9 @@ def to_gbq(dataframe, destination_table, project_id, chunksize=10000,
             connector.delete_and_recreate_table(
                 dataset_id, table_id, table_schema)
         elif if_exists == 'append':
-            if not connector.verify_schema(dataset_id, table_id, table_schema):
+            if not connector.schema_is_subset(dataset_id,
+                                              table_id,
+                                              table_schema):
                 raise InvalidSchema("Please verify that the structure and "
                                     "data types in the DataFrame match the "
                                     "schema of the destination table.")

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -637,7 +637,7 @@ class GbqConnector(object):
             Name of the BigQuery dataset for the table
         table_id : str
             Name of the BigQuery table
-        schema : list(dict)  
+        schema : list(dict)
             Schema for comparison. Each item should have
             a 'name' and a 'type'
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -563,11 +563,17 @@ class GbqConnector(object):
         Obtain from BigQuery the field names and field types
         for the table defined by the parameters
 
-        :param str dataset_id: Name of the BigQuery dataset for the table
-        :param str table_id: Name of the BigQuery table
+        Parameters
+        ----------
+        dataset_id : str
+            Name of the BigQuery dataset for the table
+        table_id : str
+            Name of the BigQuery table
 
-        :return: Fields representing the schema
-        :rtype: list of dicts
+        Returns
+        -------
+        list of dicts
+            Fields representing the schema
         """
 
         try:
@@ -596,13 +602,20 @@ class GbqConnector(object):
         the schema passed in and indicate whether all fields in the former
         are present in the latter. Order is not considered.
 
-        :param str dataset_id: Name of the BigQuery dataset for the table
-        :param str table_id: Name of the BigQuery table
-        :param list(dict) schema: Schema for comparison. Each item should have
+        Parameters
+        ----------
+        dataset_id :str
+            Name of the BigQuery dataset for the table
+        table_id : str
+            Name of the BigQuery table
+        schema : list(dict)
+            Schema for comparison. Each item should have
             a 'name' and a 'type'
 
-        :return: Whether the schemas match
-        :rtype: bool
+        Returns
+        -------
+        bool
+            Whether the schemas match
         """
 
         fields_remote = sorted(self.schema(dataset_id, table_id),
@@ -618,13 +631,20 @@ class GbqConnector(object):
         the schema passed in and indicate whether a subset of the fields in
         the former are present in the latter. Order is not considered.
 
-        :param str dataset_id: Name of the BigQuery dataset for the table
-        :param str table_id: Name of the BigQuery table
-        :param list(dict) schema: Schema for comparison. Each item should have
+        Parameters
+        ----------
+        dataset_id : str
+            Name of the BigQuery dataset for the table
+        table_id : str
+            Name of the BigQuery table
+        schema : list(dict)  
+            Schema for comparison. Each item should have
             a 'name' and a 'type'
 
-        :return: Whether the passed schema is a subset
-        :rtype: bool
+        Returns
+        -------
+        bool
+            Whether the passed schema is a subset
         """
 
         fields_remote = self.schema(dataset_id, table_id)

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -880,7 +880,8 @@ def to_gbq(dataframe, destination_table, project_id, chunksize=10000,
     if_exists : {'fail', 'replace', 'append'}, default 'fail'
         'fail': If table exists, do nothing.
         'replace': If table exists, drop it, recreate it, and insert data.
-        'append': If table exists, insert data. Create if does not exist.
+        'append': If table exists and the dataframe schema is a subset of the destination table
+        schema, insert data. Create destination table if does not exist.
     private_key : str (optional)
         Service account private key in JSON format. Can be file path
         or string contents. This is useful for remote server

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -880,8 +880,9 @@ def to_gbq(dataframe, destination_table, project_id, chunksize=10000,
     if_exists : {'fail', 'replace', 'append'}, default 'fail'
         'fail': If table exists, do nothing.
         'replace': If table exists, drop it, recreate it, and insert data.
-        'append': If table exists and the dataframe schema is a subset of the destination table
-        schema, insert data. Create destination table if does not exist.
+        'append': If table exists and the dataframe schema is a subset of
+        the destination table schema, insert data. Create destination table
+        if does not exist.
     private_key : str (optional)
         Service account private key in JSON format. Can be file path
         or string contents. This is useful for remote server

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1072,7 +1072,8 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
                        private_key=_get_private_key_path())
 
     def test_upload_subset_columns_if_table_exists_append(self):
-        # For pull request #24
+        # Issue 24: Upload is succesful if dataframe has columns
+        # which are a subset of the current schema
         test_id = "16"
         test_size = 10
         df = make_mixed_dataframe_v2(test_size)
@@ -1283,7 +1284,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
             self.dataset_prefix + "1", TABLE_ID + test_id, test_schema_2)
 
     def test_retrieve_schema(self):
-        # For pull request #24
+        # Issue #24 schema function returns the schema in biquery
         test_id = "15"
         test_schema = {'fields': [{'name': 'A', 'type': 'FLOAT'},
                                   {'name': 'B', 'type': 'FLOAT'},
@@ -1296,7 +1297,8 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
         assert expected == actual, 'Expected schema used to create table'
 
     def test_schema_is_subset_passes_if_subset(self):
-        # For pull request #24
+        # Issue #24 schema_is_subset indicates whether the schema of the
+        # dataframe is a subset of the schema of the bigquery table
         test_id = '16'
 
         table_name = TABLE_ID + test_id

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -250,21 +250,6 @@ def make_mixed_dataframe_v2(test_size):
                      index=range(test_size))
 
 
-def wait_for_job(job):
-
-    # from
-    # https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/bigquery/cloud-client/snippets.py
-
-    while True:
-        job.reload()  # Refreshes the state via a GET request.
-        if job.state == 'DONE':
-            if job.error_result:
-                raise RuntimeError(job.errors)
-            return
-        logging.info("Waiting for {} to complete".format(job))
-        sleep(1)
-
-
 def test_generate_bq_schema_deprecated():
     # 11121 Deprecation of generate_bq_schema
     with tm.assert_produces_warning(FutureWarning):
@@ -1034,7 +1019,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_path())
 
-        wait_for_job()
+        sleep(30)  # <- Curses Google!!!
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1072,7 +1057,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    if_exists='append', private_key=_get_private_key_path())
 
-        wait_for_job()
+        sleep(30)  # <- Curses Google!!!
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1103,7 +1088,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
                    self.destination_table + test_id, _get_project_id(),
                    if_exists='append', private_key=_get_private_key_path())
 
-        wait_for_job()
+        sleep(30)  # <- Curses Google!!!
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1126,7 +1111,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
                    _get_project_id(), if_exists='replace',
                    private_key=_get_private_key_path())
 
-        wait_for_job()
+        sleep(30)  # <- Curses Google!!!
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1460,7 +1445,7 @@ class TestToGBQIntegrationWithLocalUserAccountAuth(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    chunksize=10000)
 
-        wait_for_job()
+        sleep(30)  # <- Curses Google!!!
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}".format(
             self.destination_table + test_id),
@@ -1518,7 +1503,7 @@ class TestToGBQIntegrationWithServiceAccountKeyContents(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_contents())
 
-        wait_for_job()
+        sleep(30)  # <- Curses Google!!!
 
         result = gbq.read_gbq("SELECT COUNT(*) as num_rows FROM {0}".format(
             self.destination_table + test_id),

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -250,6 +250,21 @@ def make_mixed_dataframe_v2(test_size):
                      index=range(test_size))
 
 
+def wait_for_job(job):
+
+    # from
+    # https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/bigquery/cloud-client/snippets.py
+
+    while True:
+        job.reload()  # Refreshes the state via a GET request.
+        if job.state == 'DONE':
+            if job.error_result:
+                raise RuntimeError(job.errors)
+            return
+        logging.info("Waiting for {} to complete".format(job))
+        sleep(1)
+
+
 def test_generate_bq_schema_deprecated():
     # 11121 Deprecation of generate_bq_schema
     with tm.assert_produces_warning(FutureWarning):
@@ -1019,7 +1034,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_path())
 
-        sleep(30)  # <- Curses Google!!!
+        wait_for_job()
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1057,7 +1072,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    if_exists='append', private_key=_get_private_key_path())
 
-        sleep(30)  # <- Curses Google!!!
+        wait_for_job()
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1088,7 +1103,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
                    self.destination_table + test_id, _get_project_id(),
                    if_exists='append', private_key=_get_private_key_path())
 
-        sleep(30)  # <- Curses Google!!!
+        wait_for_job()
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1111,7 +1126,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
                    _get_project_id(), if_exists='replace',
                    private_key=_get_private_key_path())
 
-        sleep(30)  # <- Curses Google!!!
+        wait_for_job()
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
                               .format(self.destination_table + test_id),
@@ -1445,7 +1460,7 @@ class TestToGBQIntegrationWithLocalUserAccountAuth(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    chunksize=10000)
 
-        sleep(30)  # <- Curses Google!!!
+        wait_for_job()
 
         result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}".format(
             self.destination_table + test_id),
@@ -1503,7 +1518,7 @@ class TestToGBQIntegrationWithServiceAccountKeyContents(object):
         gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_contents())
 
-        sleep(30)  # <- Curses Google!!!
+        wait_for_job()
 
         result = gbq.read_gbq("SELECT COUNT(*) as num_rows FROM {0}".format(
             self.destination_table + test_id),

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1071,6 +1071,30 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
                        _get_project_id(), if_exists='append',
                        private_key=_get_private_key_path())
 
+    def test_upload_subset_columns_if_table_exists_append(self):
+        # For pull request #24
+        test_id = "16"
+        test_size = 10
+        df = make_mixed_dataframe_v2(test_size)
+        df_subset_cols = df.iloc[:, :2]
+
+        # Initialize table with sample data
+        gbq.to_gbq(df, self.destination_table + test_id, _get_project_id(),
+                   chunksize=10000, private_key=_get_private_key_path())
+
+        # Test the if_exists parameter with value 'append'
+        gbq.to_gbq(df_subset_cols,
+                   self.destination_table + test_id, _get_project_id(),
+                   if_exists='append', private_key=_get_private_key_path())
+
+        sleep(30)  # <- Curses Google!!!
+
+        result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
+                              .format(self.destination_table + test_id),
+                              project_id=_get_project_id(),
+                              private_key=_get_private_key_path())
+        assert result['num_rows'][0] == test_size * 2
+
     def test_upload_data_if_table_exists_replace(self):
         test_id = "4"
         test_size = 10
@@ -1257,6 +1281,65 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
         self.table.create(TABLE_ID + test_id, test_schema_1)
         assert self.sut.verify_schema(
             self.dataset_prefix + "1", TABLE_ID + test_id, test_schema_2)
+
+    def test_retrieve_schema(self):
+        # For pull request #24
+        test_id = "15"
+        test_schema = {'fields': [{'name': 'A', 'type': 'FLOAT'},
+                                  {'name': 'B', 'type': 'FLOAT'},
+                                  {'name': 'C', 'type': 'STRING'},
+                                  {'name': 'D', 'type': 'TIMESTAMP'}]}
+
+        self.table.create(TABLE_ID + test_id, test_schema)
+        actual = self.sut.schema(self.dataset_prefix + "1", TABLE_ID + test_id)
+        expected = test_schema['fields']
+        assert expected == actual, 'Expected schema used to create table'
+
+    def test_schema_is_subset_passes_if_subset(self):
+        # For pull request #24
+        test_id = '16'
+
+        table_name = TABLE_ID + test_id
+        dataset = self.dataset_prefix + '1'
+
+        table_schema = {'fields': [{'name': 'A',
+                                    'type': 'FLOAT'},
+                                   {'name': 'B',
+                                    'type': 'FLOAT'},
+                                   {'name': 'C',
+                                    'type': 'STRING'}]}
+        tested_schema = {'fields': [{'name': 'A',
+                                     'type': 'FLOAT'},
+                                    {'name': 'B',
+                                     'type': 'FLOAT'}]}
+
+        self.table.create(table_name, table_schema)
+
+        assert self.sut.schema_is_subset(
+            dataset, table_name, tested_schema) is True
+
+    def test_schema_is_subset_fails_if_not_subset(self):
+        # For pull request #24
+        test_id = '17'
+
+        table_name = TABLE_ID + test_id
+        dataset = self.dataset_prefix + '1'
+
+        table_schema = {'fields': [{'name': 'A',
+                                    'type': 'FLOAT'},
+                                   {'name': 'B',
+                                    'type': 'FLOAT'},
+                                   {'name': 'C',
+                                    'type': 'STRING'}]}
+        tested_schema = {'fields': [{'name': 'A',
+                                     'type': 'FLOAT'},
+                                    {'name': 'C',
+                                     'type': 'FLOAT'}]}
+
+        self.table.create(table_name, table_schema)
+
+        assert self.sut.schema_is_subset(
+            dataset, table_name, tested_schema) is False
 
     def test_list_dataset(self):
         dataset_id = self.dataset_prefix + "1"


### PR DESCRIPTION
## Purpose
Current behavior of `to_gbq` is fail if the schema of the new data is not equivalent to the current schema. However, this means that the load fails if the new data is missing columns that are present in the current schema. For instance, this may occur when the data source I am using to construct the dataframe only provides non-empty values. Rather than determining the current schema of the GBQ table and adding empty columns to my dataframe, I would like `to_gbq` to load my data if the columns in the dataframe are a subset of the current schema.

## Primary changes made

- Factoring a `schema` function out of `verify_schema` to support both `verify_schema` and  `schema_is_subset`
- `schema_is_subset` determines whether `local_schema` is a subset of `remote_schema`
- the append flag uses `schema_is_subset` rather than `verify_schema` to determine if the data can be loaded

## Auxiliary changes made

- `PROJECT_ID` etc are retrieved from an environment variable to facilitate local testing
- Running `test_gbq` through autopep8 added a row after two class names

