### PR TITLE
DOC: link to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+See the [contributing guide in the pandas-gbq
+docs](http://pandas-gbq.readthedocs.io/en/latest/contributing.html).
+


### PR DESCRIPTION
Full contributing (and testing) instructions are included in the docs.
http://pandas-gbq.readthedocs.io/en/latest/contributing.html

I didn't find these docs https://github.com/pydata/pandas-gbq/issues/27 because I didn't expect them to be in the user documentation, and I'm used to looking for a `CONTRIBUTING` file.

By creating a `CONTRIBUTING.md` file, GitHub users will be more likely to
find them. See: https://github.com/blog/1184-contributing-guidelines