### PR TITLE
TST: Load integration test creds from env vars

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -230,7 +230,14 @@ Running Google BigQuery Integration Tests
 You will need to create a Google BigQuery private key in JSON format in
 order to run Google BigQuery integration tests on your local machine and
 on Travis-CI. The first step is to create a `service account
-<https://console.developers.google.com/iam-admin/serviceaccounts/>`__.
+<https://console.cloud.google.com/iam-admin/serviceaccounts/>`__.
+
+To run the integration tests locally, set the following environment variables
+before running ``pytest``:
+
+#. ``GBQ_PROJECT_ID`` with the value being the ID of your BigQuery project.
+#. ``GBQ_GOOGLE_APPLICATION_CREDENTIALS`` with the value being the *path* to
+   the JSON key that you downloaded for your service account.
 
 Integration tests are skipped in pull requests because the credentials that
 are required for running Google BigQuery integration tests are
@@ -248,8 +255,8 @@ gbq integration tests on a forked repository:
 
    - ``GBQ_PROJECT_ID`` with the value being the ID of your BigQuery project.
 
-   - ``SERVICE_ACCOUNT_KEY`` with the value being the contents of the JSON key
-     that you downloaded for your service account. Use single quotes around
+   - ``SERVICE_ACCOUNT_KEY`` with the value being the *contents* of the JSON
+     key that you downloaded for your service account. Use single quotes around
      your JSON key to ensure that it is treated as a string.
 
    For both environment variables, keep the "Display value in build log" option

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -19,9 +19,6 @@ from pandas_gbq import gbq
 import pandas.util.testing as tm
 from pandas.compat.numpy import np_datetime64_compat
 
-PROJECT_ID = None
-PRIVATE_KEY_JSON_PATH = None
-PRIVATE_KEY_JSON_CONTENTS = None
 
 TABLE_ID = 'new_test'
 
@@ -66,10 +63,7 @@ def _get_dataset_prefix_random():
 
 
 def _get_project_id():
-    if _in_travis_environment():
-        return os.environ.get('GBQ_PROJECT_ID')
-    else:
-        return PROJECT_ID
+    return os.environ.get('GBQ_PROJECT_ID')
 
 
 def _get_private_key_path():
@@ -77,16 +71,16 @@ def _get_private_key_path():
         return os.path.join(*[os.environ.get('TRAVIS_BUILD_DIR'), 'ci',
                               'travis_gbq.json'])
     else:
-        return PRIVATE_KEY_JSON_PATH
+        return os.environ.get('GBQ_GOOGLE_APPLICATION_CREDENTIALS')
 
 
 def _get_private_key_contents():
-    if _in_travis_environment():
-        with open(os.path.join(*[os.environ.get('TRAVIS_BUILD_DIR'), 'ci',
-                                 'travis_gbq.json'])) as f:
-            return f.read()
-    else:
-        return PRIVATE_KEY_JSON_CONTENTS
+    key_path = _get_private_key_path()
+    if key_path is None:
+        return None
+
+    with open(key_path) as f:
+        return f.read()
 
 
 def _test_imports():


### PR DESCRIPTION
Load the credentials for integration tests from environment variables.
This will make it easier to run the integration tests locally. Also adds
instructions for running the integrations tests locally.

Closes #27.