### PR TITLE
ENH: Supporting REPEATED schema for list types

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1079,8 +1079,11 @@ def _generate_bq_schema(df, default_type='STRING'):
 
     fields = []
     for column_name, dtype in df.dtypes.iteritems():
-        fields.append({'name': column_name,
-                       'type': type_mapping.get(dtype.kind, default_type)})
+        definition = {'name': column_name,
+                      'type': type_mapping.get(dtype.kind, default_type)}
+        if isinstance(getattr(df, column_name)[0], list):
+            definition['mode'] = 'REPEATED'
+        fields.append(definition)
 
     return {'fields': fields}
 

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1092,11 +1092,14 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
         assert schema == test_schema
 
     def test_generate_repeated_schema(self):
-        df = DataFrame([{'A': [1, 2, 3], 'B': ['1', '2']}, {'A': [3, 5], 'B': ['8', '3']}])
+        df = DataFrame([{'A': [1, 2, 3], 'B': ['1', '2']},
+                        {'A': [3, 5], 'B': ['8', '3']}])
         schema = gbq._generate_bq_schema(df)
 
-        test_schema = {'fields': [{'name': 'A', 'type': 'INTEGER', 'mode': 'REPEATED'},
-                                  {'name': 'B', 'type': 'STRING', 'mode': 'REPEATED'}]}
+        test_schema = {'fields': [
+            {'name': 'A', 'type': 'INTEGER', 'mode': 'REPEATED'},
+            {'name': 'B', 'type': 'STRING', 'mode': 'REPEATED'}
+        ]}
 
         assert schema == test_schema
 

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1091,6 +1091,15 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(object):
 
         assert schema == test_schema
 
+    def test_generate_repeated_schema(self):
+        df = DataFrame([{'A': [1, 2, 3], 'B': ['1', '2']}, {'A': [3, 5], 'B': ['8', '3']}])
+        schema = gbq._generate_bq_schema(df)
+
+        test_schema = {'fields': [{'name': 'A', 'type': 'INTEGER', 'mode': 'REPEATED'},
+                                  {'name': 'B', 'type': 'STRING', 'mode': 'REPEATED'}]}
+
+        assert schema == test_schema
+
     def test_create_table(self):
         test_id = "6"
         schema = gbq._generate_bq_schema(tm.makeMixedDataFrame())


### PR DESCRIPTION
Basically, at the moment if there are lists inside a column, we have no way to put that data in GBQ. This enables REPEAT mode in a simple way.