### PR TITLE
ENH: BQ Job Id in verbose output

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,8 @@ Changelog
 - Drop support for Python 3.4 (:issue:`40`)
 - The dataframe passed to ```.to_gbq(...., if_exists='append')``` needs to contain only a subset of the fields in the BigQuery schema. (:issue:`24`)
 - Use the `google-auth <https://google-auth.readthedocs.io/en/latest/>`__ library for authentication because oauth2client is deprecated. (:issue:`39`)
-- ``read_gbq`` now has a ``auth_local_webserver`` boolean argument for controlling whether to use web server or console flow when getting user credentials. Replaces `--noauth_local_webserver` command line argument (:issue:`35`)
+- ``read_gbq`` now has a ``auth_local_webserver`` boolean argument for controlling whether to use web server or console flow when getting user credentials. Replaces `--noauth_local_webserver` command line argument. (:issue:`35`)
+- ``read_gbq`` now displays the BigQuery Job ID in verbose output. (:issue:`70`)
 
 0.1.6 / 2017-05-03
 ------------------

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -514,7 +514,7 @@ class GbqConnector(object):
             self._print('Requesting query... ', end="")
             query_reply = job_collection.insert(
                 projectId=self.project_id, body=job_data).execute()
-            self._print('ok.\nQuery running...')
+            self._print('ok.')
         except (RefreshError, ValueError):
             if self.private_key:
                 raise AccessDenied(
@@ -527,13 +527,15 @@ class GbqConnector(object):
             self.process_http_error(ex)
 
         job_reference = query_reply['jobReference']
+        job_id = job_reference['jobId']
+        self._print('Job ID: %s\nQuery running...' % job_id)
 
         while not query_reply.get('jobComplete', False):
             self.print_elapsed_seconds('  Elapsed', 's. Waiting...')
             try:
                 query_reply = job_collection.getQueryResults(
                     projectId=job_reference['projectId'],
-                    jobId=job_reference['jobId']).execute()
+                    jobId=job_id).execute()
             except HttpError as ex:
                 self.process_http_error(ex)
 
@@ -584,7 +586,7 @@ class GbqConnector(object):
             try:
                 query_reply = job_collection.getQueryResults(
                     projectId=job_reference['projectId'],
-                    jobId=job_reference['jobId'],
+                    jobId=job_id,
                     pageToken=page_token).execute()
             except HttpError as ex:
                 self.process_http_error(ex)


### PR DESCRIPTION
Hi,
After few years of BQ usage I've reached point where I need to report support case to Google BQ Team.
I've attached my iPython notebook with pandas gbq output, but they needed query Job IDs.

This is simple change to add them in read_gbq.

I'm not using to_gbq at all so I've not added verbose output for it when I implemented read_gbq some time ago. Today it is still not much verbose so I leaving things as they are.