### PR TITLE
ENH: Add timeout support

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.2.1 / ?
+------------------
+
+- :func:`read_gbq` now handles query configuration `query.timeoutMs` and stop waiting. (:issue:`76`)
+
 0.2.0 / 2017-07-24
 ------------------
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -172,6 +172,13 @@ class NotFoundException(ValueError):
     pass
 
 
+class QueryTimeout(ValueError):
+    """
+    Raised when the query job timeout
+    """
+    pass
+
+
 class StreamingInsertError(ValueError):
     """
     Raised when BigQuery reports a streaming insert error.
@@ -542,6 +549,10 @@ class GbqConnector(object):
                     jobId=job_id).execute()
             except HttpError as ex:
                 self.process_http_error(ex)
+
+            timeoutMs = job_config['query'].get('timeoutMs')
+            if timeoutMs and timeoutMs < self.get_elapsed_seconds()*1000:
+                raise QueryTimeout('Query timeout: {} ms'.format(timeoutMs))
 
         if self.verbose:
             if query_reply['cacheHit']:

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -544,9 +544,9 @@ class GbqConnector(object):
         while not query_reply.get('jobComplete', False):
             self.print_elapsed_seconds('  Elapsed', 's. Waiting...')
 
-            timeoutMs = job_config['query'].get('timeoutMs')
-            if timeoutMs and timeoutMs < self.get_elapsed_seconds() * 1000:
-                raise QueryTimeout('Query timeout: {} ms'.format(timeoutMs))
+            timeout_ms = job_config['query'].get('timeoutMs')
+            if timeout_ms and timeout_ms < self.get_elapsed_seconds() * 1000:
+                raise QueryTimeout('Query timeout: {} ms'.format(timeout_ms))
 
             try:
                 query_reply = job_collection.getQueryResults(

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -551,7 +551,7 @@ class GbqConnector(object):
                 self.process_http_error(ex)
 
             timeoutMs = job_config['query'].get('timeoutMs')
-            if timeoutMs and timeoutMs < self.get_elapsed_seconds()*1000:
+            if timeoutMs and timeoutMs < self.get_elapsed_seconds() * 1000:
                 raise QueryTimeout('Query timeout: {} ms'.format(timeoutMs))
 
         if self.verbose:

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -543,16 +543,17 @@ class GbqConnector(object):
 
         while not query_reply.get('jobComplete', False):
             self.print_elapsed_seconds('  Elapsed', 's. Waiting...')
+
+            timeoutMs = job_config['query'].get('timeoutMs')
+            if timeoutMs and timeoutMs < self.get_elapsed_seconds() * 1000:
+                raise QueryTimeout('Query timeout: {} ms'.format(timeoutMs))
+
             try:
                 query_reply = job_collection.getQueryResults(
                     projectId=job_reference['projectId'],
                     jobId=job_id).execute()
             except HttpError as ex:
                 self.process_http_error(ex)
-
-            timeoutMs = job_config['query'].get('timeoutMs')
-            if timeoutMs and timeoutMs < self.get_elapsed_seconds() * 1000:
-                raise QueryTimeout('Query timeout: {} ms'.format(timeoutMs))
 
         if self.verbose:
             if query_reply['cacheHit']:

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -884,6 +884,19 @@ class TestReadGBQIntegrationWithServiceAccountKeyPath(object):
                          private_key=_get_private_key_path(),
                          configuration=config)
 
+    def test_timeout_configuration(self):
+        sql_statement = 'SELECT 1'
+        config = {
+            'query': {
+                "timeoutMs": 1
+            }
+        }
+        # Test that QueryTimeout error raises
+        with pytest.raises(gbq.QueryTimeout):
+            gbq.read_gbq(sql_statement, project_id=_get_project_id(),
+                         private_key=_get_private_key_path(),
+                         configuration=config)
+
     def test_query_response_bytes(self):
         assert self.gbq_connector.sizeof_fmt(999) == "999.0 B"
         assert self.gbq_connector.sizeof_fmt(1024) == "1.0 KB"


### PR DESCRIPTION
pandas-gbq seems to wait for query results forever.
In rare cases, query does not finish long time (e.g. in 60 minutes) although the same query always finishes in few minutes.

I added timeout handling using configuration.query.timeoutMs.

https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query


Example
```python
import pandas as pd
import pandas_gbq.gbq

try:
    df = pd.read_gbq(query, project_id=xxx, configuration={
        'query': {'timeoutMs': 40000}
    })
    print(df.head())
except pandas_gbq.gbq.QueryTimeout as e:
    print(e)
    pass
```

Output
```
Requesting query... ok.
Job ID: job_8OSgsu7nYKNYycnlgAB2_KWTGGk
Query running...
  Elapsed 13.78 s. Waiting...
  Elapsed 25.08 s. Waiting...
  Elapsed 36.27 s. Waiting...
Query timeout: 40000 ms
```