### PR TITLE
ENH: Save BigQuery account credentials in a hidden user folder

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.3.0 / 2017-??-??
+0.2.1 / 2017-??-??
 ------------------
 
 - :func:`read_gbq` now raises ``QueryTimeout`` if the request exceeds the ``query.timeoutMs`` value specified in the BigQuery configuration. (:issue:`76`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,12 +1,12 @@
 Changelog
 =========
 
-0.2.1 / 2017-??-??
+0.3.0 / 2017-??-??
 ------------------
 
 - :func:`read_gbq` now raises ``QueryTimeout`` if the request exceeds the ``query.timeoutMs`` value specified in the BigQuery configuration. (:issue:`76`)
 - Environment variable ``PANDAS_GBQ_CREDENTIALS_FILE`` can now be used to override the default location where the BigQuery user account credentials are stored. (:issue:`86`)
-
+- BigQuery user account credentials are now stored in an application-specific hidden user folder on the operating system. (:issue:`41`)
 
 0.2.0 / 2017-07-24
 ------------------

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -37,7 +37,9 @@ is possible with either user or service account credentials.
 Authentication via user account credentials is as simple as following the prompts in a browser window
 which will automatically open for you. You authenticate to the specified
 ``BigQuery`` account using the product name ``pandas GBQ``.
-The remote authentication is supported via specifying ``auth_local_webserver`` in ``read_gbq``.
+The remote authentication is supported via the ``auth_local_webserver`` in ``read_gbq``. By default,
+account credentials are stored in an application-specific hidden user folder on the operating system. You
+can override the default credentials location via the ``PANDAS_GBQ_CREDENTIALS_FILE`` environment variable.
 Additional information on the authentication mechanism can be found
 `here <https://developers.google.com/identity/protocols/OAuth2#clientside/>`__.
 

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1388,6 +1388,7 @@ class TestToGBQIntegrationWithLocalUserAccountAuth(object):
         # put here any instruction you want to be run *BEFORE* *EVERY* test
         # is executed.
 
+        gbq.GbqConnector(_get_project_id(), auth_local_webserver=True)
         self.dataset_prefix = _get_dataset_prefix_random()
         clean_gbq_environment(self.dataset_prefix)
         self.destination_table = "{0}{1}.{2}".format(self.dataset_prefix, "2",


### PR DESCRIPTION
Closes #41

This PR adds ability for users to choose the location where BigQuery user account credentials will be stored via the `credentials_path` parameter.

This PR also changes the location of the file `bigquery_credentials.dat` that contains the BigQuery user account credentials. Previously this file was saved in the current working directory. The credentials file will now be stored in an application-specific hidden user folder on the operating system. On windows, this path is specified in the `APPDATA` environment variable as defined [here](https://technet.microsoft.com/en-ca/library/cc749104(v=ws.10).aspx) which is typically `'C:\Documents and Settings\username\Application Data\pandas-gbq\'` . Otherwise, credentials will be stored in `'~/.config/pandas-gbq/'`. If the file `bigquery_credentials.dat` is found in the current working directory, the file will be moved to the new location. 

@tswast @jreback Please could you take a look at your earliest convenience?