### PR TITLE
Support for replacing date partitioned tables

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 - :func:`_Table.exists` correctly ignores the partition decorator in case it is provided
 - :func:`_Table.create` now supports the possibility to pass extra table resource details, allowing partitioned table creationsphinx-quickstart
 - :func:`read_gbq` now raises ``QueryTimeout`` if the request exceeds the ``query.timeoutMs`` value specified in the BigQuery configuration. (:issue:`76`)
+- :func:`_Dataset.delete` now supports the delete_contents parameter
 
 0.2.0 / 2017-07-24
 ------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 0.2.1 / 2017-??-??
 ------------------
 
+- Added support for replacing date partitioned tables (:issue:`43`), :func:`to_tbq` can be used regularly with a partition decorator
+- :func:`GbqConnector.copy` allows to create a copy job
+- :func:`_Table.contains_partition_decorator` returns whether the table_id contains a $ character
+- :func:`_Table.exists` correctly ignores the partition decorator in case it is provided
+- :func:`_Table.create` now supports the possibility to pass extra table resource details, allowing partitioned table creationsphinx-quickstart
 - :func:`read_gbq` now raises ``QueryTimeout`` if the request exceeds the ``query.timeoutMs`` value specified in the BigQuery configuration. (:issue:`76`)
 
 0.2.0 / 2017-07-24

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1066,7 +1066,7 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
         else:
             raise InvalidIndexColumn(
                 'Index column "{0}" does not exist in DataFrame.'
-                .format(index_col)
+                    .format(index_col)
             )
 
     # Change the order of columns in the DataFrame based on provided list
@@ -1533,13 +1533,17 @@ class _Dataset(GbqConnector):
         except self.http_error as ex:
             self.process_http_error(ex)
 
-    def delete(self, dataset_id):
+    def delete(self, dataset_id, delete_contents=False):
         """ Delete a dataset in Google BigQuery
 
         Parameters
         ----------
         dataset : str
             Name of dataset to be deleted
+        delete_contents : boolean
+            If True, delete all the tables in the dataset. 
+            If False and the dataset contains tables, 
+            the request will fail. Default is False
         """
 
         if not self.exists(dataset_id):
@@ -1549,7 +1553,8 @@ class _Dataset(GbqConnector):
         try:
             self.service.datasets().delete(
                 datasetId=dataset_id,
-                projectId=self.project_id).execute()
+                projectId=self.project_id,
+                deleteContents=delete_contents).execute()
 
         except self.http_error as ex:
             # Ignore 404 error which may occur if dataset already deleted

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -866,11 +866,12 @@ class GbqConnector(object):
             Whether the schemas match
         """
 
-        fields_remote = sorted(self.schema(dataset_id, table_id), key=lambda x: x['name'])
-        fields_local = sorted(schema['fields'], key=lambda x: x['name'])
-
-        fields_remote = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_remote]
-        fields_local = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_local]
+        fields_remote = sorted([{'name': f['name'].lower(), 'type': f['type']}
+                                for f in self.schema(dataset_id, table_id)],
+                               key=lambda x: x['name'])
+        fields_local = sorted([{'name': f['name'].lower(), 'type': f['type']}
+                               for f in schema['fields']],
+                              key=lambda x: x['name'])
 
         return fields_remote == fields_local
 
@@ -897,11 +898,10 @@ class GbqConnector(object):
             Whether the passed schema is a subset
         """
 
-        fields_remote = self.schema(dataset_id, table_id)
-        fields_local = schema['fields']
-
-        fields_remote = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_remote]
-        fields_local = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_local]
+        fields_remote = [{'name': f['name'].lower(), 'type': f['type']}
+                         for f in self.schema(dataset_id, table_id)]
+        fields_local = [{'name': f['name'].lower(), 'type': f['type']}
+                        for f in schema['fields']]
 
         return all(field in fields_remote for field in fields_local)
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -866,9 +866,11 @@ class GbqConnector(object):
             Whether the schemas match
         """
 
-        fields_remote = sorted(self.schema(dataset_id, table_id),
-                               key=lambda x: x['name'])
+        fields_remote = sorted(self.schema(dataset_id, table_id), key=lambda x: x['name'])
         fields_local = sorted(schema['fields'], key=lambda x: x['name'])
+
+        fields_remote = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_remote]
+        fields_local = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_local]
 
         return fields_remote == fields_local
 
@@ -897,6 +899,9 @@ class GbqConnector(object):
 
         fields_remote = self.schema(dataset_id, table_id)
         fields_local = schema['fields']
+
+        fields_remote = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_remote]
+        fields_local = [{'name': f['name'].lower(), 'type': f['type']} for f in fields_local]
 
         return all(field in fields_remote for field in fields_local)
 

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1521,8 +1521,10 @@ class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
                                   {'name': 'B', 'type': 'FLOAT'},
                                   {'name': 'C', 'type': 'STRING'},
                                   {'name': 'D', 'type': 'TIMESTAMP'}]}
-        self.table.create(TABLE_ID + test_id, test_schema, body={'timePartitioning': {'type': 'DAY'}})
-        actual = self.sut.resource(self.dataset_prefix + "1", TABLE_ID + test_id)
+        self.table.create(TABLE_ID + test_id, test_schema,
+                          body={'timePartitioning': {'type': 'DAY'}})
+        actual = self.sut.resource(self.dataset_prefix +
+                                   "1", TABLE_ID + test_id)
         assert actual['timePartitioning']['type'] == 'DAY'
 
     def test_upload_data_to_partition(self):
@@ -1533,7 +1535,8 @@ class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
         self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df),
                           body={'timePartitioning': {'type': 'DAY'}})
 
-        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+        partition_name = self.destination_table + test_id + \
+            '$' + datetime.today().strftime("%Y%m%d")
 
         gbq.to_gbq(df, partition_name, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_path())
@@ -1551,7 +1554,8 @@ class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
         test_size = 20001
         df = make_mixed_dataframe_v2(test_size)
 
-        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+        partition_name = self.destination_table + test_id + \
+            '$' + datetime.today().strftime("%Y%m%d")
 
         with pytest.raises(gbq.NotFoundException):
             gbq.to_gbq(df, partition_name, _get_project_id(),
@@ -1564,7 +1568,8 @@ class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
 
         self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df))
 
-        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+        partition_name = self.destination_table + test_id + \
+            '$' + datetime.today().strftime("%Y%m%d")
 
         with pytest.raises(gbq.InvalidSchema):
             gbq.to_gbq(df, partition_name, _get_project_id(),
@@ -1574,9 +1579,11 @@ class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
         test_id = "3"
         test_size = 10
         df = make_mixed_dataframe_v2(test_size)
-        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df), body={'timePartitioning': {'type': 'DAY'}})
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df),
+                          body={'timePartitioning': {'type': 'DAY'}})
 
-        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+        partition_name = self.destination_table + test_id + \
+            '$' + datetime.today().strftime("%Y%m%d")
 
         gbq.to_gbq(df, partition_name, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_path())
@@ -1596,9 +1603,11 @@ class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
         test_size = 10
         df = make_mixed_dataframe_v2(test_size)
         df_different_schema = tm.makeMixedDataFrame()
-        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df), body={'timePartitioning': {'type': 'DAY'}})
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df),
+                          body={'timePartitioning': {'type': 'DAY'}})
 
-        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+        partition_name = self.destination_table + test_id + \
+            '$' + datetime.today().strftime("%Y%m%d")
 
         gbq.to_gbq(df, partition_name, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_path())
@@ -1628,9 +1637,11 @@ class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
         df = make_mixed_dataframe_v2(test_size)
         df2 = make_mixed_dataframe_v2(expected_size)
         df_different_schema = tm.makeMixedDataFrame()
-        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df), body={'timePartitioning': {'type': 'DAY'}})
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df),
+                          body={'timePartitioning': {'type': 'DAY'}})
 
-        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+        partition_name = self.destination_table + test_id + \
+            '$' + datetime.today().strftime("%Y%m%d")
 
         gbq.to_gbq(df, partition_name, _get_project_id(),
                    chunksize=10000, private_key=_get_private_key_path())

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1471,3 +1471,182 @@ class TestToGBQIntegrationWithServiceAccountKeyContents(object):
             project_id=_get_project_id(),
             private_key=_get_private_key_contents())
         assert result['num_rows'][0] == test_size
+
+
+class TestToPartitionGBQIntegrationWithServiceAccountKeyPath(object):
+    @classmethod
+    def setup_class(cls):
+        # - GLOBAL CLASS FIXTURES -
+        # put here any instruction you want to execute only *ONCE* *BEFORE*
+        # executing *ALL* tests described below.
+
+        _skip_if_no_project_id()
+        _skip_if_no_private_key_path()
+
+        _setup_common()
+
+    def setup_method(self, method):
+        # - PER-TEST FIXTURES -
+        # put here any instruction you want to be run *BEFORE* *EVERY* test is
+        # executed.
+
+        self.dataset_prefix = _get_dataset_prefix_random()
+        clean_gbq_environment(self.dataset_prefix, _get_private_key_path())
+        self.dataset = gbq._Dataset(_get_project_id(),
+                                    private_key=_get_private_key_path())
+        self.table = gbq._Table(_get_project_id(), self.dataset_prefix + "1",
+                                private_key=_get_private_key_path())
+        self.sut = gbq.GbqConnector(_get_project_id(),
+                                    private_key=_get_private_key_path())
+        self.destination_table = "{0}{1}.{2}".format(self.dataset_prefix, "1",
+                                                     TABLE_ID)
+        self.dataset.create(self.dataset_prefix + "1")
+
+    @classmethod
+    def teardown_class(cls):
+        # - GLOBAL CLASS FIXTURES -
+        # put here any instruction you want to execute only *ONCE* *AFTER*
+        # executing all tests.
+        pass
+
+    def teardown_method(self, method):
+        # - PER-TEST FIXTURES -
+        # put here any instructions you want to be run *AFTER* *EVERY* test is
+        # executed.
+        clean_gbq_environment(self.dataset_prefix, _get_private_key_path())
+
+    def test_create_partitioned_table(self):
+        test_id = "1"
+        test_schema = {'fields': [{'name': 'A', 'type': 'FLOAT'},
+                                  {'name': 'B', 'type': 'FLOAT'},
+                                  {'name': 'C', 'type': 'STRING'},
+                                  {'name': 'D', 'type': 'TIMESTAMP'}]}
+        self.table.create(TABLE_ID + test_id, test_schema, body={'timePartitioning': {'type': 'DAY'}})
+        actual = self.sut.resource(self.dataset_prefix + "1", TABLE_ID + test_id)
+        assert actual['timePartitioning']['type'] == 'DAY'
+
+    def test_upload_data_to_partition(self):
+        test_id = "2"
+        test_size = 20001
+        df = make_mixed_dataframe_v2(test_size)
+
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df),
+                          body={'timePartitioning': {'type': 'DAY'}})
+
+        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+
+        gbq.to_gbq(df, partition_name, _get_project_id(),
+                   chunksize=10000, private_key=_get_private_key_path())
+
+        sleep(30)  # <- Curses Google!!!
+
+        result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
+                              .format(partition_name),
+                              project_id=_get_project_id(),
+                              private_key=_get_private_key_path())
+        assert result['num_rows'][0] == test_size
+
+    def test_upload_data_to_partition_non_existing_table(self):
+        test_id = "2"
+        test_size = 20001
+        df = make_mixed_dataframe_v2(test_size)
+
+        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+
+        with pytest.raises(gbq.NotFoundException):
+            gbq.to_gbq(df, partition_name, _get_project_id(),
+                       chunksize=10000, private_key=_get_private_key_path())
+
+    def test_upload_data_to_partition_non_partitioned_table(self):
+        test_id = "2"
+        test_size = 20001
+        df = make_mixed_dataframe_v2(test_size)
+
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df))
+
+        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+
+        with pytest.raises(gbq.InvalidSchema):
+            gbq.to_gbq(df, partition_name, _get_project_id(),
+                       chunksize=10000, private_key=_get_private_key_path())
+
+    def test_upload_data_if_partition_exists_fail(self):
+        test_id = "3"
+        test_size = 10
+        df = make_mixed_dataframe_v2(test_size)
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df), body={'timePartitioning': {'type': 'DAY'}})
+
+        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+
+        gbq.to_gbq(df, partition_name, _get_project_id(),
+                   chunksize=10000, private_key=_get_private_key_path())
+
+        # Test the default value of if_exists is 'fail'
+        with pytest.raises(gbq.TableCreationError):
+            gbq.to_gbq(df, partition_name, _get_project_id(),
+                       private_key=_get_private_key_path())
+
+        # Test the if_exists parameter with value 'fail'
+        with pytest.raises(gbq.TableCreationError):
+            gbq.to_gbq(df, partition_name, _get_project_id(),
+                       if_exists='fail', private_key=_get_private_key_path())
+
+    def test_upload_data_if_partition_exists_append(self):
+        test_id = "3"
+        test_size = 10
+        df = make_mixed_dataframe_v2(test_size)
+        df_different_schema = tm.makeMixedDataFrame()
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df), body={'timePartitioning': {'type': 'DAY'}})
+
+        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+
+        gbq.to_gbq(df, partition_name, _get_project_id(),
+                   chunksize=10000, private_key=_get_private_key_path())
+
+        # Test the if_exists parameter with value 'append'
+        gbq.to_gbq(df, partition_name, _get_project_id(),
+                   if_exists='append', private_key=_get_private_key_path())
+
+        sleep(30)  # <- Curses Google!!!
+
+        result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
+                              .format(partition_name),
+                              project_id=_get_project_id(),
+                              private_key=_get_private_key_path())
+        assert result['num_rows'][0] == test_size * 2
+
+        # Try inserting with a different schema, confirm failure
+        with pytest.raises(gbq.InvalidSchema):
+            gbq.to_gbq(df_different_schema, partition_name,
+                       _get_project_id(), if_exists='append',
+                       private_key=_get_private_key_path())
+
+    def test_upload_data_if_partition_exists_replace(self):
+        test_id = "4"
+        test_size = 10
+        expected_size = 25
+        df = make_mixed_dataframe_v2(test_size)
+        df2 = make_mixed_dataframe_v2(expected_size)
+        df_different_schema = tm.makeMixedDataFrame()
+        self.table.create(TABLE_ID + test_id, gbq._generate_bq_schema(df), body={'timePartitioning': {'type': 'DAY'}})
+
+        partition_name = self.destination_table + test_id + '$' + datetime.today().strftime("%Y%m%d")
+
+        gbq.to_gbq(df, partition_name, _get_project_id(),
+                   chunksize=10000, private_key=_get_private_key_path())
+
+        # Test the if_exists parameter with value 'replace'
+        gbq.to_gbq(df2, partition_name, _get_project_id(),
+                   if_exists='replace', private_key=_get_private_key_path())
+
+        result = gbq.read_gbq("SELECT COUNT(*) AS num_rows FROM {0}"
+                              .format(partition_name),
+                              project_id=_get_project_id(),
+                              private_key=_get_private_key_path())
+        assert result['num_rows'][0] == expected_size
+
+        # Try inserting with a different schema, confirm failure
+        with pytest.raises(gbq.InvalidSchema):
+            gbq.to_gbq(df_different_schema, partition_name,
+                       _get_project_id(), if_exists='replace',
+                       private_key=_get_private_key_path())


### PR DESCRIPTION
I addressed the enhancement request in #43, now it is possible to replace data in a partition. 
A few other minor changes have been added to give a full support of date partitioned tables (creation and insertion were missing mainly).
I also added a copy function, which is a convenient (and free) way to move data in BigQuery.