### PR TITLE
Add execute_sql function to enable execution of SQL code where no DataFrame is returned

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -874,6 +874,94 @@ def _parse_entry(field_value, field_type):
     return field_value
 
 
+def execute_sql(query, project_id=None, index_col=None, col_order=None,
+                reauth=False, verbose=True, private_key=None,
+                auth_local_webserver=False, dialect='legacy', **kwargs):
+    r"""Execute SQL query on Google BigQuery.
+
+    The main method a user calls to execute a Query in Google BigQuery. This
+    method should be used for statements like INSERT, CREATE TABLE, UPDATE etc.
+    where a DataFrame is not returned.
+
+    Google BigQuery API Client Library v2 for Python is used.
+    Documentation is available `here
+    <https://developers.google.com/api-client-library/python/apis/bigquery/v2>`__
+
+    Authentication to the Google BigQuery service is via OAuth 2.0.
+
+    - If "private_key" is not provided:
+
+      By default "application default credentials" are used.
+
+      If default application credentials are not found or are restrictive,
+      user account credentials are used. In this case, you will be asked to
+      grant permissions for product name 'pandas GBQ'.
+
+    - If "private_key" is provided:
+
+      Service account credentials will be used to authenticate.
+
+    Parameters
+    ----------
+    query : str
+        SQL-Like Query to be executed.
+    project_id : str
+        Google BigQuery Account project ID.
+    index_col : str (optional)
+        Name of result column to use for index in results DataFrame
+    col_order : list(str) (optional)
+        List of BigQuery column names in the desired order for results
+        DataFrame
+    reauth : boolean (default False)
+        Force Google BigQuery to reauthenticate the user. This is useful
+        if multiple accounts are used.
+    verbose : boolean (default True)
+        Verbose output
+    private_key : str (optional)
+        Service account private key in JSON format. Can be file path
+        or string contents. This is useful for remote server
+        authentication (eg. jupyter iPython notebook on remote host)
+    auth_local_webserver : boolean, default False
+        Use the [local webserver flow] instead of the [console flow] when
+        getting user credentials. A file named bigquery_credentials.dat will
+        be created in current dir. You can also set PANDAS_GBQ_CREDENTIALS_FILE
+        environment variable so as to define a specific path to store this
+        credential (eg. /etc/keys/bigquery.dat).
+
+        .. [local webserver flow]
+            http://google-auth-oauthlib.readthedocs.io/en/latest/reference/google_auth_oauthlib.flow.html#google_auth_oauthlib.flow.InstalledAppFlow.run_local_server
+        .. [console flow]
+            http://google-auth-oauthlib.readthedocs.io/en/latest/reference/google_auth_oauthlib.flow.html#google_auth_oauthlib.flow.InstalledAppFlow.run_console
+        .. versionadded:: 0.2.0
+
+    dialect : {'legacy', 'standard'}, default 'legacy'
+        'legacy' : Use BigQuery's legacy SQL dialect.
+        'standard' : Use BigQuery's standard SQL (beta), which is
+        compliant with the SQL 2011 standard. For more information
+        see `BigQuery SQL Reference
+        <https://cloud.google.com/bigquery/sql-reference/>`__
+
+    **kwargs : Arbitrary keyword arguments
+        configuration (dict): query config parameters for job processing.
+        For example:
+
+            configuration = {'query': {'useQueryCache': False}}
+
+        For more information see `BigQuery SQL Reference
+        <https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query>`__
+
+    """
+
+    try:
+        read_gbq(query, project_id=project_id, index_col=index_col,
+                 col_order=col_order, reauth=reauth, verbose=verbose,
+                 private_key=private_key,
+                 auth_local_webserver=auth_local_webserver,
+                 dialect=dialect, **kwargs)
+    except KeyError:
+        pass
+
+
 def read_gbq(query, project_id=None, index_col=None, col_order=None,
              reauth=False, verbose=True, private_key=None,
              auth_local_webserver=False, dialect='legacy', **kwargs):


### PR DESCRIPTION
Initial pull request based on the discussion and issue explained [here](https://github.com/pydata/pandas-gbq/issues/45). I'd love to discuss any changes to the design of this function, or if it might be better to add this functionality elsewhere.