### PR TITLE
Prepare for 0.2.1 release.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.2.1 / 2017-??-??
+0.2.1 / 2017-11-27
 ------------------
 
 - :func:`read_gbq` now raises ``QueryTimeout`` if the request exceeds the ``query.timeoutMs`` value specified in the BigQuery configuration. (:issue:`76`)

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -530,7 +530,7 @@ class GbqConnector(object):
     def run_query(self, query, **kwargs):
         try:
             from googleapiclient.errors import HttpError
-        except:
+        except ImportError:
             from apiclient.errors import HttpError
         from google.auth.exceptions import RefreshError
 
@@ -663,7 +663,7 @@ class GbqConnector(object):
     def load_data(self, dataframe, dataset_id, table_id, chunksize):
         try:
             from googleapiclient.errors import HttpError
-        except:
+        except ImportError:
             from apiclient.errors import HttpError
 
         job_id = uuid.uuid4().hex
@@ -737,7 +737,7 @@ class GbqConnector(object):
 
         try:
             from googleapiclient.errors import HttpError
-        except:
+        except ImportError:
             from apiclient.errors import HttpError
 
         try:
@@ -1162,7 +1162,7 @@ class _Table(GbqConnector):
                  private_key=None):
         try:
             from googleapiclient.errors import HttpError
-        except:
+        except ImportError:
             from apiclient.errors import HttpError
         self.http_error = HttpError
         self.dataset_id = dataset_id
@@ -1261,7 +1261,7 @@ class _Dataset(GbqConnector):
                  private_key=None):
         try:
             from googleapiclient.errors import HttpError
-        except:
+        except ImportError:
             from apiclient.errors import HttpError
         self.http_error = HttpError
         super(_Dataset, self).__init__(project_id, reauth, verbose,


### PR DESCRIPTION
Before https://github.com/pydata/pandas-gbq/pull/25 goes in, which will mark version `0.3.0`, I think it would be smart to make a release with the bug fixes that have happened since `0.2.0`.