### PR TITLE
BUG: Fix bug in type conversion of arrays; add array and struct tests

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Use the `google-cloud-bigquery <https://googlecloudplatform.github.io/google-cloud-python/latest/bigquery/usage.html>`__ library for API calls. The ``google-cloud-bigquery`` package is a new dependency, and dependencies on ``google-api-python-client`` and ``httplib2`` are removed. See the `installation guide <https://pandas-gbq.readthedocs.io/en/latest/install.html#dependencies>`__ for more details.  (:issue:`93`)
+- Structs and arrays are now named properly (:issue:`23`) and BigQuery functions like ``array_agg`` no longer run into errors during type conversion (:issue:`22`).
 - :func:`to_gbq` now uses a load job instead of the streaming API. Remove ``StreamingInsertError`` class, as it is no longer used by :func:`to_gbq`. (:issue:`7`, :issue:`75`)
 
 0.2.1 / 2017-11-27

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -867,11 +867,12 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
             )
 
     # cast BOOLEAN and INTEGER columns from object to bool/int
-    # if they dont have any nulls
+    # if they dont have any nulls AND field mode is not repeated (i.e., array)
     type_map = {'BOOLEAN': bool, 'INTEGER': int}
     for field in schema['fields']:
         if field['type'].upper() in type_map and \
-                final_df[field['name']].notnull().all():
+                final_df[field['name']].notnull().all() and \
+                field['mode'] != 'repeated':
             final_df[field['name']] = \
                 final_df[field['name']].astype(type_map[field['type'].upper()])
 


### PR DESCRIPTION
As per @tswast's requests in https://github.com/pydata/pandas-gbq/issues/22 and https://github.com/pydata/pandas-gbq/issues/23, tests added to check that arrays and structs are successfully returned and named properly from a query.

While running tests, identified a bug with the type conversion in read_gbq (see below). Updated it so it only performs type conversion with the added condition that the returned field mode IS NOT `repeated`.

### To re-produce type conversion error with array:
```
>>> import gbq
>>> query = """WITH t as (
...         SELECT "a" letter, 1 num
...         UNION ALL
...         SELECT "b" letter, 2 num
...         UNION ALL
...         SELECT "a" letter, 3 num)
...
...         select letter, array_agg(num order by num ASC) num_array
...         from t
...         group by letter"""
>>> df = gbq.read_gbq(query, project_id='XXXXX',dialect='standard',verbose=False)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "gbq.py", line 877, in read_gbq
    final_df[field['name']].astype(type_map[field['type'].upper()])
  File "/Users/jasonng/anaconda2/lib/python2.7/site-packages/pandas/util/_decorators.py", line 118, in wrapper
    return func(*args, **kwargs)
  File "/Users/jasonng/anaconda2/lib/python2.7/site-packages/pandas/core/generic.py", line 4004, in astype
    **kwargs)
  File "/Users/jasonng/anaconda2/lib/python2.7/site-packages/pandas/core/internals.py", line 3462, in astype
    return self.apply('astype', dtype=dtype, **kwargs)
  File "/Users/jasonng/anaconda2/lib/python2.7/site-packages/pandas/core/internals.py", line 3329, in apply
    applied = getattr(b, f)(**kwargs)
  File "/Users/jasonng/anaconda2/lib/python2.7/site-packages/pandas/core/internals.py", line 544, in astype
    **kwargs)
  File "/Users/jasonng/anaconda2/lib/python2.7/site-packages/pandas/core/internals.py", line 625, in _astype
    values = astype_nansafe(values.ravel(), dtype, copy=True)
  File "/Users/jasonng/anaconda2/lib/python2.7/site-packages/pandas/core/dtypes/cast.py", line 692, in astype_nansafe
    return lib.astype_intsafe(arr.ravel(), dtype).reshape(arr.shape)
  File "pandas/_libs/lib.pyx", line 854, in pandas._libs.lib.astype_intsafe
  File "pandas/_libs/src/util.pxd", line 91, in util.set_value_at_unsafe
ValueError: setting an array element with a sequence.
```