### PR TITLE
Disable codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,9 @@ coverage:
     project:
       default:
         target: '0'
+        enabled: no
     patch:
       default:
+        enabled: no
         target: '50'
         branches: null


### PR DESCRIPTION
Currently every PR fails the codecov test, with codecov stats I don't think are correct 

Open to a better way to do this, but disabling is better than the current state