### PR TITLE
BUG: Explicitly use 64bit integers when converting from BQ types

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -848,7 +848,7 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
 
     # cast BOOLEAN and INTEGER columns from object to bool/int
     # if they dont have any nulls AND field mode is not repeated (i.e., array)
-    type_map = {'BOOLEAN': bool, 'INTEGER': int}
+    type_map = {'BOOLEAN': bool, 'INTEGER': np.int64}
     for field in schema['fields']:
         if field['type'].upper() in type_map and \
                 final_df[field['name']].notnull().all() and \


### PR DESCRIPTION
Solved issue #119 
On 64-bit windows 10 the `int` values are cast into 32-bit integers for reasons given here
https://stackoverflow.com/questions/36278590/numpy-array-dtype-is-coming-as-int32-by-default-in-a-windows-10-64-bit-machine
This leads to unhandled exceptions when handling values beyond 32-bit signed range
In Bigquery, int is always 64bit, so the solution is to specify the data type explicitly