### PR TITLE
BUG: Add support to replace partitions in date-partitioned tables (#43)

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -337,10 +337,6 @@ class GbqConnector(object):
         This method authenticates using user credentials, either loading saved
         credentials from a file or by going through the OAuth flow.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         GoogleCredentials : credentials
@@ -567,7 +563,7 @@ class GbqConnector(object):
         try:
             for remaining_rows in _load.load_chunks(
                     self.client, dataframe, dataset_id, table_id,
-                    chunksize=chunksize):
+                    chunksize=chunksize, schema=schema):
                 self._print("\rLoad is {0}% Complete".format(
                     ((total_rows - remaining_rows) * 100) / total_rows))
         except self.http_error as ex:

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1023,7 +1023,7 @@ class _Table(GbqConnector):
 
         Parameters
         ----------
-        table : str
+        table_id : str
             Name of table to be verified
 
         Returns
@@ -1051,7 +1051,7 @@ class _Table(GbqConnector):
 
         Parameters
         ----------
-        table : str
+        table_id : str
             Name of table to be written
         schema : str
             Use the generate_bq_schema to generate your table schema from a
@@ -1099,7 +1099,7 @@ class _Table(GbqConnector):
 
         Parameters
         ----------
-        table : str
+        table_id : str
             Name of table to be deleted
         """
         from google.api_core.exceptions import NotFound
@@ -1178,7 +1178,7 @@ class _Dataset(GbqConnector):
 
         Parameters
         ----------
-        dataset : str
+        dataset_id : str
             Name of dataset to be written
         """
         from google.cloud.bigquery import Dataset
@@ -1199,7 +1199,7 @@ class _Dataset(GbqConnector):
 
         Parameters
         ----------
-        dataset : str
+        dataset_id : str
             Name of dataset to be deleted
         """
         from google.api_core.exceptions import NotFound
@@ -1222,7 +1222,7 @@ class _Dataset(GbqConnector):
 
         Parameters
         ----------
-        dataset : str
+        dataset_id : str
             Name of dataset to list tables for
 
         Returns

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -695,7 +695,7 @@ class GbqConnector(object):
         table = _Table(self.project_id, dataset_id,
                        private_key=self.private_key)
         table.delete(table_id)
-        if not _Table.is_date_partitioned(table_id):
+        if not table.is_date_partitioned(table_id):
             table.create(table_id, table_schema)
             sleep(delay)
 


### PR DESCRIPTION
Relates to issue #43 

Changes:
* Ability to write into a partition of a date-partitioned table by the module inferring insert into a partitioned table from the table decorator or if specified by user
* Styling and docstring edits
* Fix use schema when appending data to a table with an existing schema (ie. regular appends or date-partitioned tables inserts)
Needs:
* Tests for:
  - stuff is in the right partition
  - only the target partition is affected
  - ?