### PR TITLE
Fix array of floats bug

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.3.2 / [TBD]
+------------------
+- Fix bug with querying for an array of floats (:issue:`123`)
+
 0.3.1 / 2018-02-13
 ------------------
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -720,6 +720,8 @@ def _parse_data(schema, rows):
     col_names = [str(field['name']) for field in fields]
     col_dtypes = [
         dtype_map.get(field['type'].upper(), object)
+        if field['mode'] != 'repeated'
+        else object
         for field in fields
     ]
     page_array = np.zeros((len(rows),), dtype=lzip(col_names, col_dtypes))

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -973,6 +973,14 @@ class TestReadGBQIntegrationWithServiceAccountKeyPath(object):
         tm.assert_frame_equal(df, DataFrame([["a", [1, 3]], ["b", [2]]],
                               columns=["letter", "numbers"]))
 
+    def test_array_of_floats(self):
+        query = """select [1.1, 2.2, 3.3] as a, 4 as b"""
+        df = gbq.read_gbq(query, project_id=_get_project_id(),
+                          private_key=_get_private_key_path(),
+                          dialect='standard')
+        tm.assert_frame_equal(df, DataFrame([[[1.1, 2.2, 3.3], 4]],
+                              columns=["a", "b"]))
+
 
 class TestToGBQIntegrationWithServiceAccountKeyPath(object):
     # Changes to BigQuery table schema may take up to 2 minutes as of May 2015


### PR DESCRIPTION
This PR resolves the bug documented here: https://github.com/pydata/pandas-gbq/issues/123

Basically, the custom dtype handling we have to convert missing values to NaNs fails when the field in BigQuery is an array (that is, in repeated mode). We simply set the dtype to an object if it is an array.

Added a test to check for this in the future. All previous tests still pass. Can also verify the bug and that this fixes by running:

```
gbq.read_gbq("select [1.1,2.2,3.3]","project",dialect="standard")
```

@tswast @MtDersvan