### PR TITLE
CLN: isort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-gi#########################################
+#########################################
 # Editor temporary/working/backup files #
 .#*
 *\#*\#
@@ -19,6 +19,8 @@ gi#########################################
 .noseids
 .ipynb_checkpoints
 .tags
+.pytest_cache
+.testmondata
 
 # Docs #
 ########

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,7 @@
 #
 import os
 import sys
+
 # sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------

--- a/pandas_gbq/_load.py
+++ b/pandas_gbq/_load.py
@@ -1,7 +1,7 @@
 """Helper methods for loading data into BigQuery"""
 
-from google.cloud import bigquery
 import six
+from google.cloud import bigquery
 
 from pandas_gbq import _schema
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1,15 +1,14 @@
+import json
+import os
+import sys
+import time
 import warnings
 from datetime import datetime
-import json
-import time
+from distutils.version import StrictVersion
 from time import sleep
-import sys
-import os
 
 import numpy as np
-
-from distutils.version import StrictVersion
-from pandas import compat, DataFrame
+from pandas import DataFrame, compat
 from pandas.compat import lzip
 
 

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import logging
 import os
 import re
 import sys

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -15,6 +15,7 @@ import pytz
 from pandas import DataFrame, NaT, compat
 from pandas.compat import range, u
 from pandas.compat.numpy import np_datetime64_compat
+
 from pandas_gbq import gbq
 
 try:

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1,26 +1,22 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
-import re
-from datetime import datetime
-import pytz
-from time import sleep
-import os
-from random import randint
 import logging
+import os
+import re
 import sys
+from datetime import datetime
+from random import randint
+from time import sleep
 
 import numpy as np
-
-from pandas import compat
-
-from pandas.compat import u, range
-from pandas import NaT, DataFrame
-from pandas_gbq import gbq
 import pandas.util.testing as tm
+import pytest
+import pytz
+from pandas import DataFrame, NaT, compat
+from pandas.compat import range, u
 from pandas.compat.numpy import np_datetime64_compat
 
+from pandas_gbq import gbq
 
 TABLE_ID = 'new_test'
 

--- a/scripts/merge-py.py
+++ b/scripts/merge-py.py
@@ -25,15 +25,14 @@
 
 from __future__ import print_function
 
-from subprocess import check_output
-from requests.auth import HTTPBasicAuth
-import requests
-
 import os
-import six
 import sys
 import textwrap
+from subprocess import check_output
 
+import requests
+import six
+from requests.auth import HTTPBasicAuth
 from six.moves import input
 
 PANDASGBQ_HOME = '.'

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,8 @@ parentdir_prefix = pandas_gbq-
 
 [flake8]
 ignore = E731
+
+[isort]
+default_section=THIRDPARTY
+known_first_party=pandas_gbq
+multi_line_output=4

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
 import versioneer
-
+from setuptools import find_packages, setup
 
 NAME = 'pandas-gbq'
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -277,16 +277,18 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 """
 
 from __future__ import print_function
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+
 import errno
 import json
 import os
 import re
 import subprocess
 import sys
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 
 class VersioneerConfig:


### PR DESCRIPTION
Ran `isort -y`

Not worth enforcing I think, but occasional clean-ups (marginally) helpful