### PR TITLE
Remove console flow

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,9 @@ Changelog
 0.3.2 / [TBD]
 ------------------
 - Fix bug with querying for an array of floats (:issue:`123`)
+- Removed Console Flow from user auth, making Local Webserver the default.
+  When attempting to auth, a browser will attempted to be opened. Should that
+  fail, you can copy and paste the URL as before
 
 0.3.1 / 2018-02-13
 ------------------

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -174,7 +174,7 @@ class GbqConnector(object):
         self.project_id = project_id
         self.reauth = reauth
         self.verbose = verbose
-        self.private_key = private_key©
+        self.private_key = private_key
         self.dialect = dialect
         self.credentials_path = _get_credentials_file()
         self.credentials = self.get_credentials()


### PR DESCRIPTION
The Console Flow is a strict subset of the functionality of the Local Webserver - if the browser fails to open, it's exactly the same. It makes writing parameterized tests harder, and is a small contributor to overall gunk