### PR TITLE
add @stickler-ci

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,6 @@
+linters:
+  flake8:
+    max-line-length: 79
+    fixer: true
+fixers:
+  enable: true


### PR DESCRIPTION
We've got this running in xarray, and it's pretty good - much nicer to get a PR comment before the travis fail. 

https://github.com/pydata/xarray/pull/1913

One question is whether we want it adding changes automatically, in addition to the standard PR comments. I thought it was good but others didn't, so we decided to turn it off there. I've enabled it here, but open-minded.

Someone with commit privileges needs to start it checking here: https://stickler-ci.com/repositories 