### PR TITLE
BUG: fixed a bug that all TIMESTAMP fileds become 00 secconds.

### DIFF
--- a/pandas_gbq/_load.py
+++ b/pandas_gbq/_load.py
@@ -15,7 +15,7 @@ def encode_chunk(dataframe):
     csv_buffer = six.StringIO()
     dataframe.to_csv(
         csv_buffer, index=False, header=False, encoding='utf-8',
-        date_format='%Y-%m-%d %H:%M')
+        date_format='%Y-%m-%d %H:%M:%S.%f')
 
     # Convert to a BytesIO buffer so that unicode text is properly handled.
     # See: https://github.com/pydata/pandas-gbq/issues/106

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1394,8 +1394,7 @@ class TestToGBQIntegration(object):
         test_size = 6
         df = DataFrame(np.random.randn(test_size, 4), index=range(test_size),
                        columns=list('ABCD'))
-        test_timestamp = datetime.now(pytz.timezone('UTC'))
-        df['times'] = test_timestamp
+        df['times'] = np.datetime64('2018-03-13T05:40:45.348318Z')
 
         gbq.to_gbq(
             df, self.destination_table + test_id,
@@ -1409,8 +1408,8 @@ class TestToGBQIntegration(object):
 
         assert len(result_df) == test_size
 
-        expected = df['times'].astype('M8[ns]').sort_values()
-        result = result_df['times'].astype('M8[ns]').sort_values()
+        expected = df['times'].sort_values()
+        result = result_df['times'].sort_values()
         tm.assert_numpy_array_equal(expected.values, result.values)
 
     def test_list_dataset(self):


### PR DESCRIPTION
Fixed a bug that all TIMESTAMP fileds become 00 secconds in BigQuery.
https://github.com/pydata/pandas-gbq/issues/69#issuecomment-366431134  mentions to same issue.

* before ( note: In this case, I intentionally puts same datetime.now() value. )

<img width="448" alt="screen shot 2018-03-12 at 18 13 52" src="https://user-images.githubusercontent.com/13819005/37275467-ab442ec8-2622-11e8-8ddc-0483d2326687.png">

* after

<img width="441" alt="screen shot 2018-03-12 at 18 24 05" src="https://user-images.githubusercontent.com/13819005/37275481-b32915ea-2622-11e8-930d-95738945af34.png">
