### PR TITLE
Load data with user defined schema

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -562,7 +562,7 @@ class GbqConnector(object):
         try:
             for remaining_rows in _load.load_chunks(
                     self.client, dataframe, dataset_id, table_id,
-                    chunksize=chunksize):
+                    chunksize=chunksize, schema=schema):
                 self._print("\rLoad is {0}% Complete".format(
                     ((total_rows - remaining_rows) * 100) / total_rows))
         except self.http_error as ex:

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1412,6 +1412,23 @@ class TestToGBQIntegration(object):
         result = result_df['times'].sort_values()
         tm.assert_numpy_array_equal(expected.values, result.values)
 
+    def test_upload_data_with_different_df_and_user_schema(self):
+        df = tm.makeMixedDataFrame()
+        df['A'] = df['A'].astype(str)
+        df['B'] = df['B'].astype(str)
+        test_id = "22"
+        test_schema = [{'name': 'A', 'type': 'FLOAT'},
+                       {'name': 'B', 'type': 'FLOAT'},
+                       {'name': 'C', 'type': 'STRING'},
+                       {'name': 'D', 'type': 'TIMESTAMP'}]
+        destination_table = self.destination_table + test_id
+        gbq.to_gbq(df, destination_table, _get_project_id(),
+                   private_key=self.credentials,
+                   table_schema=test_schema)
+        dataset, table = destination_table.split('.')
+        assert self.table.verify_schema(dataset, table,
+                                        dict(fields=test_schema))
+
     def test_list_dataset(self):
         dataset_id = self.dataset_prefix + "1"
         assert dataset_id in self.dataset.datasets()


### PR DESCRIPTION
The `to_gbp` function fails when there is a user-defined schema which is slightly different from the schema of DataFrame.

Traceback:

```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "pandas_gbq/gbq.py", line 979, in to_gbq
    schema=table_schema)
  File "pandas_gbq/gbq.py", line 569, in load_data
    self.process_http_error(ex)
  File "pandas_gbq/gbq.py", line 450, in process_http_error
    raise GenericGBQException("Reason: {0}".format(ex))
pandas_gbq.gbq.GenericGBQException: Reason: 400 POST https://www.googleapis.com/upload/bigquery/v2/projects/aktech-labs/jobs?uploadType=resumable: Provided Schema does not match Table aktech-labs:pandas_test.gamma. Field A has changed type from FLOAT to STRING
```

The primary reason for this is that the `load_data` function ignores the `schema` argument.

Solution: The `schema` argument is now passed to the `load_chunks` function inside `load_data` function. A suitable integration test has been added.