### PR TITLE
BUG: Adapt to breaking change in google-cloud-bigquery 0.32.0.dev1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ install:
       conda install -q numpy pytz python-dateutil;
       PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com";
       pip install --pre --upgrade --timeout=60 -f $PRE_WHEELS pandas;
+      pip install -e 'git+https://github.com/GoogleCloudPlatform/google-cloud-python.git#egg=version_subpkg&subdirectory=api_core';
+      pip install -e 'git+https://github.com/GoogleCloudPlatform/google-cloud-python.git#egg=version_subpkg&subdirectory=core';
+      pip install -e 'git+https://github.com/GoogleCloudPlatform/google-cloud-python.git#egg=version_subpkg&subdirectory=bigquery';
     else
       conda install -q pandas=$PANDAS;
     fi

--- a/ci/requirements-3.5-0.18.1.pip
+++ b/ci/requirements-3.5-0.18.1.pip
@@ -1,4 +1,4 @@
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
 mock
-google-cloud-bigquery==0.32.0
+google-cloud-bigquery==0.29.0

--- a/ci/requirements-3.5-0.18.1.pip
+++ b/ci/requirements-3.5-0.18.1.pip
@@ -1,4 +1,4 @@
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
 mock
-google-cloud-bigquery==0.29.0
+google-cloud-bigquery==0.32.0

--- a/ci/requirements-3.6-MASTER.pip
+++ b/ci/requirements-3.6-MASTER.pip
@@ -1,4 +1,3 @@
 google-auth
 google-auth-oauthlib
 mock
-google-cloud-bigquery

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 - Fix bug with querying for an array of floats (:issue:`123`)
 - Fix bug with integer columns on Windows. Explicitly use 64bit integers when converting from BQ types. (:issue:`119`)
-- Update ``google-cloud-python`` dependency to version 0.32.0+. Fixes bug caused by breaking change the way ``google-cloud-python`` handles additional configuration argument to ``read_gbq``. (:issue:`152`)
+- Fix bug caused by breaking change the way ``google-cloud-python`` version 0.32.0+ handles additional configuration argument to ``read_gbq``. (:issue:`152`)
 -  **Deprecates** the ``verbose`` parameter. Messages use the logging module instead of printing progress directly to standard output. (:issue:`12`)
 
 0.3.1 / 2018-02-13

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 - Fix bug with querying for an array of floats (:issue:`123`)
 - Fix bug with integer columns on Windows. Explicitly use 64bit integers when converting from BQ types. (:issue:`119`)
 - Update ``google-cloud-python`` dependency to version 0.32.0+. Fixes bug caused by breaking change the way ``google-cloud-python`` handles additional configuration argument to ``read_gbq``. (:issue:`152`)
+-  **Deprecates** the ``verbose`` parameter. Messages use the logging module instead of printing progress directly to standard output. (:issue:`12`)
 
 0.3.1 / 2018-02-13
 ------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,9 +1,11 @@
 Changelog
 =========
 
-0.3.2 / [TBD]
+0.4.0 / [TBD]
 ------------------
 - Fix bug with querying for an array of floats (:issue:`123`)
+- Fix bug with integer columns on Windows. Explicitly use 64bit integers when converting from BQ types. (:issue:`119`)
+- Update ``google-cloud-python`` dependency to version 0.32.0+ (:issue:`TBD`)
 
 0.3.1 / 2018-02-13
 ------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 - Fix bug with querying for an array of floats (:issue:`123`)
 - Fix bug with integer columns on Windows. Explicitly use 64bit integers when converting from BQ types. (:issue:`119`)
-- Update ``google-cloud-python`` dependency to version 0.32.0+ (:issue:`TBD`)
+- Update ``google-cloud-python`` dependency to version 0.32.0+. Fixes bug caused by breaking change the way ``google-cloud-python`` handles additional configuration argument to ``read_gbq``. (:issue:`152`)
 
 0.3.1 / 2018-02-13
 ------------------

--- a/pandas_gbq/_query.py
+++ b/pandas_gbq/_query.py
@@ -1,0 +1,13 @@
+
+import pkg_resources
+from google.cloud import bigquery
+
+
+# Version with query config breaking change.
+BIGQUERY_CONFIG_VERSION = pkg_resources.parse_version('0.32.0.dev1')
+
+
+def query_config(resource, installed_version):
+    if installed_version < BIGQUERY_CONFIG_VERSION:
+        return bigquery.QueryJobConfig.from_api_repr(resource.get('query', {}))
+    return bigquery.QueryJobConfig.from_api_repr(resource)

--- a/pandas_gbq/_query.py
+++ b/pandas_gbq/_query.py
@@ -7,7 +7,19 @@ from google.cloud import bigquery
 BIGQUERY_CONFIG_VERSION = pkg_resources.parse_version('0.32.0.dev1')
 
 
+def query_config_old_version(resource):
+    # Verify that we got a query resource. In newer versions of
+    # google-cloud-bigquery enough of the configuration is passed on to the
+    # backend that we can expect a backend validation error instead.
+    if len(resource) != 1:
+        raise ValueError("Only one job type must be specified, but "
+                         "given {}".format(','.join(resource.keys())))
+    if 'query' not in resource:
+        raise ValueError("Only 'query' job type is supported")
+    return bigquery.QueryJobConfig.from_api_repr(resource['query'])
+
+
 def query_config(resource, installed_version):
     if installed_version < BIGQUERY_CONFIG_VERSION:
-        return bigquery.QueryJobConfig.from_api_repr(resource.get('query', {}))
+        return query_config_old_version(resource)
     return bigquery.QueryJobConfig.from_api_repr(resource)

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -474,7 +474,9 @@ class GbqConnector(object):
         try:
             logger.info('Requesting query... ')
             query_reply = self.client.query(
-                query, job_config=_query.query_config(job_config))
+                query,
+                job_config=_query.query_config(
+                    job_config, BIGQUERY_INSTALLED_VERSION))
             logger.info('ok.\nQuery running...')
         except (RefreshError, ValueError):
             if self.private_key:

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -467,8 +467,7 @@ class GbqConnector(object):
                     raise ValueError("Query statement can't be specified "
                                      "inside config while it is specified "
                                      "as parameter")
-                query = config['query']['query']
-                del config['query']['query']
+                query = config['query'].pop('query')
 
         self._start_timer()
 

--- a/pandas_gbq/tests/test__query.py
+++ b/pandas_gbq/tests/test__query.py
@@ -1,0 +1,57 @@
+
+import pkg_resources
+
+import mock
+
+
+@mock.patch('google.cloud.bigquery.QueryJobConfig')
+def test_query_config_w_old_bq_version(mock_config):
+    from pandas_gbq._query import query_config
+
+    old_version = pkg_resources.parse_version('0.29.0')
+    query_config({'query': {'useLegacySql': False}}, old_version)
+    mock_config.from_api_repr.assert_called_once_with({'useLegacySql': False})
+
+
+@mock.patch('google.cloud.bigquery.QueryJobConfig')
+def test_query_config_w_dev_bq_version(mock_config):
+    from pandas_gbq._query import query_config
+
+    dev_version = pkg_resources.parse_version('0.32.0.dev1')
+    query_config(
+        {
+            'query': {
+                'useLegacySql': False,
+            },
+            'labels': {'key': 'value'},
+        },
+        dev_version)
+    mock_config.from_api_repr.assert_called_once_with(
+        {
+            'query': {
+                'useLegacySql': False,
+            },
+            'labels': {'key': 'value'},
+        })
+
+
+@mock.patch('google.cloud.bigquery.QueryJobConfig')
+def test_query_config_w_new_bq_version(mock_config):
+    from pandas_gbq._query import query_config
+
+    dev_version = pkg_resources.parse_version('1.0.0')
+    query_config(
+        {
+            'query': {
+                'useLegacySql': False,
+            },
+            'labels': {'key': 'value'},
+        },
+        dev_version)
+    mock_config.from_api_repr.assert_called_once_with(
+        {
+            'query': {
+                'useLegacySql': False,
+            },
+            'labels': {'key': 'value'},
+        })

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1266,10 +1266,30 @@ class TestToGBQIntegration(object):
         test_id = "15"
         test_schema = {
             'fields': [
-                {'name': 'A', 'type': 'FLOAT', 'mode': 'NULLABLE'},
-                {'name': 'B', 'type': 'FLOAT', 'mode': 'NULLABLE'},
-                {'name': 'C', 'type': 'STRING', 'mode': 'NULLABLE'},
-                {'name': 'D', 'type': 'TIMESTAMP', 'mode': 'NULLABLE'}
+                {
+                    'name': 'A',
+                    'type': 'FLOAT',
+                    'mode': 'NULLABLE',
+                    'description': None,
+                },
+                {
+                    'name': 'B',
+                    'type': 'FLOAT',
+                    'mode': 'NULLABLE',
+                    'description': None,
+                },
+                {
+                    'name': 'C',
+                    'type': 'STRING',
+                    'mode': 'NULLABLE',
+                    'description': None,
+                },
+                {
+                    'name': 'D',
+                    'type': 'TIMESTAMP',
+                    'mode': 'NULLABLE',
+                    'description': None,
+                },
             ]
         }
 

--- a/pandas_gbq/tests/test_gbq.py
+++ b/pandas_gbq/tests/test_gbq.py
@@ -1294,8 +1294,14 @@ class TestToGBQIntegration(object):
         }
 
         self.table.create(TABLE_ID + test_id, test_schema)
-        actual = self.sut.schema(self.dataset_prefix + "1", TABLE_ID + test_id)
-        expected = test_schema['fields']
+        actual = self.sut._clean_schema_fields(
+            self.sut.schema(self.dataset_prefix + "1", TABLE_ID + test_id))
+        expected = [
+            {'name': 'A', 'type': 'FLOAT'},
+            {'name': 'B', 'type': 'FLOAT'},
+            {'name': 'C', 'type': 'STRING'},
+            {'name': 'D', 'type': 'TIMESTAMP'},
+        ]
         assert expected == actual, 'Expected schema used to create table'
 
     def test_schema_is_subset_passes_if_subset(self):

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ def readme():
 
 
 INSTALL_REQUIRES = [
+    'setuptools',
     'pandas',
     'google-auth',
     'google-auth-oauthlib',


### PR DESCRIPTION
There was a breaking change in 0.32.0 which changed the way
configuration for the query job gets loaded. Also, it added the
'description' field to the schema resource, so this change updates the
schema comparison logic to account for that.

Note: I've created this PR based on the code currently in `master` in the [google-cloud-bigquery repo](https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/bigquery). The tests pass locally, but they won't pass anywhere else until google-cloud-bigquery 0.32.0 is released. I've added the **DO NOT MERGE** label to this PR for now.

Since pandas-gbq will be broken when google-cloud-bigquery does its next release, I think it would make sense to review this before than so it can be merged when everything is ready. Once it goes in, I can create a pandas-gbq release to minimize the breakage time.