### PR TITLE
DOC: Changelog for 0.4.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,12 +1,22 @@
 Changelog
 =========
 
-0.4.0 / [TBD]
+0.4.0 / 2018-04-03
 ------------------
-- Fix bug with querying for an array of floats (:issue:`123`)
-- Fix bug with integer columns on Windows. Explicitly use 64bit integers when converting from BQ types. (:issue:`119`)
-- Fix bug caused by breaking change the way ``google-cloud-python`` version 0.32.0+ handles additional configuration argument to ``read_gbq``. (:issue:`152`)
--  **Deprecates** the ``verbose`` parameter. Messages use the logging module instead of printing progress directly to standard output. (:issue:`12`)
+
+-   Fix bug in `read_gbq` when building a dataframe with integer columns
+    on Windows. Explicitly use 64bit integers when converting from BQ types.
+    (:issue:`119`)
+-   Fix bug in `read_gbq` when querying for an array of floats (:issue:`123`)
+-   Fix bug in `read_gbq` with configuration argument. Updates `read_gbq` to
+    account for breaking change in the way ``google-cloud-python`` version
+    0.32.0+ handles query configuration API representation. (:issue:`152`)
+-   Fix bug in `to_gbq` where seconds were discarded in timestamp columns.
+    (:issue:`148`)
+-   Fix bug in `to_gbq` when supplying a user-defined schema (:issue:`150`)
+-   **Deprecate** the ``verbose`` parameter in `read_gbq` and `to_gbq`.
+    Messages use the logging module instead of printing progress directly to
+    standard output. (:issue:`12`)
 
 0.3.1 / 2018-02-13
 ------------------


### PR DESCRIPTION
Preparing for a release of 0.4.0.

FYI @jreback @parthea @maxim-lian I'll kick off a release today, since I would love for this to be out ahead of the next `google-cloud-bigquery` release https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5138 (the one with the breaking changes in the query configuration)