### PR TITLE
TST: use latest version of miniconda on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     if [ -f "$REQ.pip" ]; then
       pip install --upgrade nox-automation ;
     else
-      wget http://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
       bash miniconda.sh -b -p $HOME/miniconda ;
       export PATH="$HOME/miniconda/bin:$PATH" ;
       hash -r ;
@@ -49,7 +49,7 @@ script:
   - if [[ $PYTHON == '3.6' ]] && [[ "$PANDAS" == "MASTER" ]]; then nox -s test36master ; fi
   - REQ="ci/requirements-${PYTHON}-${PANDAS}" ;
     if [ -f "$REQ.conda" ]; then
-      pytest -v tests ;
+      pytest -v tests/unit tests/system.py ;
     fi
   - if [[ $COVERAGE == 'true' ]]; then nox -s cover ; fi
   - if [[ $LINT == 'true' ]]; then nox -s lint ; fi


### PR DESCRIPTION
My local tests seem to show that https://github.com/conda-forge/google-cloud-bigquery-feedstock/issues/10 has been resolved with the latest release of Miniconda (most recent
update was on 2018-05-02).

Travis build with credentials running at https://travis-ci.org/tswast/pandas-gbq/builds/374998229