### PR TITLE
CLN: remove workaround for streaming delays.

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -4,7 +4,6 @@ import os
 import time
 import warnings
 from datetime import datetime
-from time import sleep
 
 import numpy as np
 from pandas import DataFrame, compat
@@ -690,24 +689,10 @@ class GbqConnector(object):
         return all(field in fields_remote for field in fields_local)
 
     def delete_and_recreate_table(self, dataset_id, table_id, table_schema):
-        delay = 0
-
-        # Changes to table schema may take up to 2 minutes as of May 2015 See
-        # `Issue 191
-        # <https://code.google.com/p/google-bigquery/issues/detail?id=191>`__
-        # Compare previous schema with new schema to determine if there should
-        # be a 120 second delay
-
-        if not self.verify_schema(dataset_id, table_id, table_schema):
-            logger.info('The existing table has a different schema. Please '
-                        'wait 2 minutes. See Google BigQuery issue #191')
-            delay = 120
-
         table = _Table(self.project_id, dataset_id,
                        private_key=self.private_key)
         table.delete(table_id)
         table.create(table_id, table_schema)
-        sleep(delay)
 
 
 def _get_credentials_file():

--- a/tests/system.py
+++ b/tests/system.py
@@ -872,17 +872,6 @@ class TestToGBQIntegration(object):
                               private_key=self.credentials)
         assert result['num_rows'][0] == test_size * 2
 
-    # This test is currently failing intermittently due to changes in the
-    # BigQuery backend. You can track the issue in the Google BigQuery issue
-    # tracker `here <https://issuetracker.google.com/issues/64329577>`__.
-    # Currently you need to stream data twice in order to successfully stream
-    # data when you delete and re-create a table with a different schema.
-    # Something to consider is that google-cloud-bigquery returns an array of
-    # streaming insert errors rather than raising an exception. In this
-    # scenario, a decision could be made by the user to check for streaming
-    # errors and retry as needed. See `Issue 75
-    # <https://github.com/pydata/pandas-gbq/issues/75>`__
-    @pytest.mark.xfail(reason="Delete/create table w/ different schema issue")
     def test_upload_data_if_table_exists_replace(self):
         test_id = "4"
         test_size = 10


### PR DESCRIPTION
Now that load jobs are used, no sleep is required when replacing a table.

Tests with credentials running at https://travis-ci.org/tswast/pandas-gbq/builds/375003060