### PR TITLE
TST: Lock miniconda version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     if [ -f "$REQ.pip" ]; then
       pip install --upgrade nox-automation ;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh -O miniconda.sh;
       bash miniconda.sh -b -p $HOME/miniconda ;
       export PATH="$HOME/miniconda/bin:$PATH" ;
       hash -r ;


### PR DESCRIPTION
The latest version of miniconda seems to be having a hard time with the `google.cloud` and `google.api_core` namespaced packages again. Hopefully reverting back to an old version of miniconda fixes it.