### PR TITLE
Use general float format when writing to CSV buffer to prevent numerical overload

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _changelog-0.5.1:
+
+0.5.1 / (Unreleased)
+--------------------
+
+- Use general float with 15 decimal digit precision when writing to local
+  CSV buffer in ``to_gbq``. This prevents numerical overflow in certain
+  edge cases. (:issue:`192`)
+
 .. _changelog-0.5.0:
 
 0.5.0 / 2018-06-15

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -15,7 +15,7 @@ def encode_chunk(dataframe):
     csv_buffer = six.StringIO()
     dataframe.to_csv(
         csv_buffer, index=False, header=False, encoding='utf-8',
-        date_format='%Y-%m-%d %H:%M:%S.%f')
+        float_format='%g', date_format='%Y-%m-%d %H:%M:%S.%f')
 
     # Convert to a BytesIO buffer so that unicode text is properly handled.
     # See: https://github.com/pydata/pandas-gbq/issues/106

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -15,7 +15,7 @@ def encode_chunk(dataframe):
     csv_buffer = six.StringIO()
     dataframe.to_csv(
         csv_buffer, index=False, header=False, encoding='utf-8',
-        float_format='%g', date_format='%Y-%m-%d %H:%M:%S.%f')
+        float_format='%15g', date_format='%Y-%m-%d %H:%M:%S.%f')
 
     # Convert to a BytesIO buffer so that unicode text is properly handled.
     # See: https://github.com/pydata/pandas-gbq/issues/106

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -15,7 +15,7 @@ def encode_chunk(dataframe):
     csv_buffer = six.StringIO()
     dataframe.to_csv(
         csv_buffer, index=False, header=False, encoding='utf-8',
-        float_format='%15g', date_format='%Y-%m-%d %H:%M:%S.%f')
+        float_format='%.15g', date_format='%Y-%m-%d %H:%M:%S.%f')
 
     # Convert to a BytesIO buffer so that unicode text is properly handled.
     # See: https://github.com/pydata/pandas-gbq/issues/106

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -4,6 +4,7 @@ import numpy
 import pandas
 
 from pandas_gbq import load
+from io import StringIO
 
 
 def test_encode_chunk_with_unicode():
@@ -18,6 +19,20 @@ def test_encode_chunk_with_unicode():
     csv_bytes = csv_buffer.read()
     csv_string = csv_bytes.decode('utf-8')
     assert u'信用卡' in csv_string
+
+
+def test_encode_chunk_with_floats():
+    """Test that floats in a dataframe are encoded with at most 15 significant
+        figures.
+
+    See: https://github.com/pydata/pandas-gbq/issues/192
+    """
+    input_csv = StringIO('01/01/17 23:00,1.05148,1.05153,1.05148,1.05153,4')
+    df = pandas.read_csv(input_csv, header=None)
+    csv_buffer = load.encode_chunk(df)
+    csv_bytes = csv_buffer.read()
+    csv_string = csv_bytes.decode('utf-8')
+    assert '1.05153' in csv_string
 
 
 def test_encode_chunks_splits_dataframe():
@@ -36,3 +51,5 @@ def test_encode_chunks_with_chunksize_none():
     remaining, buffer = chunks[0]
     assert remaining == 0
     assert len(buffer.readlines()) == 6
+
+

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -27,7 +27,7 @@ def test_encode_chunk_with_floats():
 
     See: https://github.com/pydata/pandas-gbq/issues/192
     """
-    input_csv = StringIO('01/01/17 23:00,1.05148,1.05153,1.05148,1.05153,4')
+    input_csv = StringIO(u'01/01/17 23:00,1.05148,1.05153,1.05148,1.05153,4')
     df = pandas.read_csv(input_csv, header=None)
     csv_buffer = load.encode_chunk(df)
     csv_bytes = csv_buffer.read()

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -51,5 +51,3 @@ def test_encode_chunks_with_chunksize_none():
     remaining, buffer = chunks[0]
     assert remaining == 0
     assert len(buffer.readlines()) == 6
-
-


### PR DESCRIPTION
## Summary

Based on issue #192.

The `load.py` module's `encode_chunk()` function writes to a local CSV buffer using Pandas' `to_csv()` function, which has a [known issue](https://stackoverflow.com/questions/12877189/float64-with-pandas-to-csv) regarding added significant figures on some operating systems. This can cause numerical overflow when loading the data into BigQuery.

This PR adds the `float_format='%.15g'` parameter to the `to_csv()` call.

## Details

This section provides a bit more detail behind the `%.15g` float format.

As per the Python 3 string format [documentation](https://docs.python.org/3.6/library/string.html#formatspec), the `g` (general) format acts as such:
> For a given precision p >= 1, this rounds the number to p significant digits and then formats the result in either fixed-point format or in scientific notation, depending on its magnitude.

BigQuery stores floats as [IEEE-754 doubles](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#floating-point-type). 15 is the maximum number of significant digits that can be used for a floating point number to guarantee that it does not overflow (according to [Wikipedia](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)):
> If a decimal string with at most 15 significant digits is converted to IEEE 754 double-precision representation, and then converted back to a decimal string with the same number of digits, the final result should match the original string.

Hence, we choose the general format with at most 15 decimal digits of precision. It reduces rounding loss from pandas to BigQuery to a minimum and does not increase storage requirements since floats are being stored as IEEE-754 doubles, anyway.