### PR TITLE
Reduce verbosity of logging

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,8 @@ Changelog
   ``DataFrame`` construction to the Pandas library, radically reducing
   the number of loops that execute in python
   (:issue:`128`)
+- Reduced verbosity of logging from ``read_gbq``, particularly for short
+  queries. (:issue:`201`)
 
 .. _changelog-0.6.0:
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -240,12 +240,12 @@ class GbqConnector(object):
         self._start_timer()
 
         try:
-            logger.info('Requesting query... ')
+            logger.debug('Requesting query... ')
             query_reply = self.client.query(
                 query,
                 job_config=bigquery.QueryJobConfig.from_api_repr(job_config),
                 location=self.location)
-            logger.info('ok.\nQuery running...')
+            logger.info('Query running...')
         except (RefreshError, ValueError):
             if self.private_key:
                 raise AccessDenied(
@@ -258,7 +258,7 @@ class GbqConnector(object):
             self.process_http_error(ex)
 
         job_id = query_reply.job_id
-        logger.info('Job ID: %s\nQuery running...' % job_id)
+        logger.debug('Job ID: %s' % job_id)
 
         while query_reply.state != 'DONE':
             self.log_elapsed_seconds('  Elapsed', 's. Waiting...')
@@ -303,8 +303,7 @@ class GbqConnector(object):
                 for field in rows_iter.schema],
         }
 
-        # log basic query stats
-        logger.info('Got {} rows.\n'.format(total_rows))
+        logger.debug('Got {} rows.\n'.format(total_rows))
 
         return schema, result_rows
 
@@ -314,7 +313,6 @@ class GbqConnector(object):
         from pandas_gbq import load
 
         total_rows = len(dataframe)
-        logger.info("\n\n")
 
         try:
             chunks = load.load_chunks(self.client, dataframe, dataset_id,
@@ -327,8 +325,6 @@ class GbqConnector(object):
                     ((total_rows - remaining_rows) * 100) / total_rows))
         except self.http_error as ex:
             self.process_http_error(ex)
-
-        logger.info("\n")
 
     def schema(self, dataset_id, table_id):
         """Retrieve the schema of the table
@@ -611,7 +607,6 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
     connector.log_elapsed_seconds(
         'Total time taken',
         datetime.now().strftime('s.\nFinished at %Y-%m-%d %H:%M:%S.'),
-        0
     )
 
     return final_df


### PR DESCRIPTION
Now we have clustering, we're looking at running more shorter queries. This PR reduces the volume of logs in INFO, particularly for short queries. 

Existing output:
```
2018-08-24 18:32:43,618 - pandas_gbq.gbq - INFO - Requesting query... 
2018-08-24 18:32:44,068 - pandas_gbq.gbq - INFO - ok.
Query running...
2018-08-24 18:32:44,073 - pandas_gbq.gbq - INFO - Job ID: d2c20d3f-97d3-44f8-b1be-ee8b10ec2818
Query running...
2018-08-24 18:32:44,700 - pandas_gbq.gbq - INFO - Got 1 rows.

2018-08-24 18:32:44,725 - pandas_gbq.gbq - INFO - Total time taken 1.11 s.
Finished at 2018-08-24 18:32:44.
 ```

New output for queries < 7s:

```
Query running...
Query running...
```

(it's repeated because we send an additional query, as per https://github.com/pydata/pandas-gbq/issues/198)

New output for queries > 7s:

```
Query running...
Query running...
2018-08-24 18:32:44,725 - pandas_gbq.gbq - INFO - Total time taken 11.87 s.
Finished at 2018-08-24 18:32:44.
```

Most of the existing output can be restored by setting the debug level to `DEBUG`. 

Ideally I think we'd replace all this with `tqdm`, but this is a quick starter