### PR TITLE
[BUG] skip _try_credentials check for to_gbq

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Changelog
   (:issue:`128`)
 - Reduced verbosity of logging from ``read_gbq``, particularly for short
   queries. (:issue:`201`)
+- Avoid ``SELECT 1`` query when running ``to_gbq``. (:issue:`202`)
 
 .. _changelog-0.6.0:
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -171,6 +171,7 @@ class GbqConnector(object):
         auth_local_webserver=False,
         dialect="legacy",
         location=None,
+        try_credentials=None,
     ):
         from google.api_core.exceptions import GoogleAPIError
         from google.api_core.exceptions import ClientError
@@ -189,6 +190,7 @@ class GbqConnector(object):
             project_id=project_id,
             reauth=reauth,
             auth_local_webserver=auth_local_webserver,
+            try_credentials=try_credentials,
         )
 
         if self.project_id is None:
@@ -804,6 +806,9 @@ def to_gbq(
         private_key=private_key,
         auth_local_webserver=auth_local_webserver,
         location=location,
+        # Avoid reads when writing tables.
+        # https://github.com/pydata/pandas-gbq/issues/202
+        try_credentials=lambda project, creds: creds,
     )
     dataset_id, table_id = destination_table.rsplit(".", 1)
 

--- a/tests/system/test_auth.py
+++ b/tests/system/test_auth.py
@@ -66,9 +66,13 @@ def test_get_application_default_credentials_does_not_throw_error():
         with mock.patch(
             "google.auth.default", side_effect=DefaultCredentialsError()
         ):
-            credentials, _ = auth.get_application_default_credentials()
+            credentials, _ = auth.get_application_default_credentials(
+                try_credentials=auth._try_credentials
+            )
     else:
-        credentials, _ = auth.get_application_default_credentials()
+        credentials, _ = auth.get_application_default_credentials(
+            try_credentials=auth._try_credentials
+        )
     assert credentials is None
 
 
@@ -77,7 +81,9 @@ def test_get_application_default_credentials_returns_credentials():
         pytest.skip("Cannot get default_credentials " "from the environment!")
     from google.auth.credentials import Credentials
 
-    credentials, default_project = auth.get_application_default_credentials()
+    credentials, default_project = auth.get_application_default_credentials(
+        try_credentials=auth._try_credentials
+    )
 
     assert isinstance(credentials, Credentials)
     assert default_project is not None
@@ -88,7 +94,9 @@ def test_get_user_account_credentials_bad_file_returns_credentials():
     from google.auth.credentials import Credentials
 
     with mock.patch("__main__.open", side_effect=IOError()):
-        credentials = auth.get_user_account_credentials()
+        credentials = auth.get_user_account_credentials(
+            try_credentials=auth._try_credentials
+        )
     assert isinstance(credentials, Credentials)
 
 
@@ -97,7 +105,9 @@ def test_get_user_account_credentials_returns_credentials(project_id):
     from google.auth.credentials import Credentials
 
     credentials = auth.get_user_account_credentials(
-        project_id=project_id, auth_local_webserver=True
+        project_id=project_id,
+        auth_local_webserver=True,
+        try_credentials=auth._try_credentials,
     )
     assert isinstance(credentials, Credentials)
 
@@ -107,6 +117,9 @@ def test_get_user_account_credentials_reauth_returns_credentials(project_id):
     from google.auth.credentials import Credentials
 
     credentials = auth.get_user_account_credentials(
-        project_id=project_id, auth_local_webserver=True, reauth=True
+        project_id=project_id,
+        auth_local_webserver=True,
+        reauth=True,
+        try_credentials=auth._try_credentials,
     )
     assert isinstance(credentials, Credentials)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -95,7 +95,9 @@ def test_get_credentials_load_user_no_default(monkeypatch):
         google.auth.credentials.Credentials
     )
 
-    def mock_load_credentials(project_id=None, credentials_path=None):
+    def mock_load_credentials(
+        try_credentials, project_id=None, credentials_path=None
+    ):
         return mock_user_credentials
 
     monkeypatch.setattr(

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -210,6 +210,17 @@ def test_to_gbq_with_verbose_old_pandas_no_warnings(recwarn, min_bq_version):
         assert len(recwarn) == 0
 
 
+def test_to_gbq_doesnt_run_query(recwarn, min_bq_version):
+    try:
+        gbq.to_gbq(
+            DataFrame([[1]]), "dataset.tablename", project_id="my-project"
+        )
+    except gbq.TableCreationError:
+        pass
+
+    gbq.GbqConnector.get_client(None).query.assert_not_called()
+
+
 def test_read_gbq_with_no_project_id_given_should_fail(monkeypatch):
     from pandas_gbq import auth
 

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -46,6 +46,7 @@ def mock_bigquery_client(monkeypatch):
     # Mock table creation.
     mock_client.get_table.side_effect = NotFound("nope")
     monkeypatch.setattr(gbq.GbqConnector, "get_client", lambda _: mock_client)
+    return mock_client
 
 
 def mock_none_credentials(*args, **kwargs):
@@ -210,7 +211,9 @@ def test_to_gbq_with_verbose_old_pandas_no_warnings(recwarn, min_bq_version):
         assert len(recwarn) == 0
 
 
-def test_to_gbq_doesnt_run_query(recwarn, min_bq_version):
+def test_to_gbq_doesnt_run_query(
+    recwarn, mock_bigquery_client, min_bq_version
+):
     try:
         gbq.to_gbq(
             DataFrame([[1]]), "dataset.tablename", project_id="my-project"
@@ -218,7 +221,7 @@ def test_to_gbq_doesnt_run_query(recwarn, min_bq_version):
     except gbq.TableCreationError:
         pass
 
-    gbq.GbqConnector.get_client(None).query.assert_not_called()
+    mock_bigquery_client.query.assert_not_called()
 
 
 def test_read_gbq_with_no_project_id_given_should_fail(monkeypatch):


### PR DESCRIPTION
Don't do a query read when all you need to write is write credentials.

Closes https://github.com/pydata/pandas-gbq/issues/202