### PR TITLE
[BUG] Don't load credentials from disk if reauth is True

### DIFF
--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -159,11 +159,13 @@ def get_user_account_credentials(
         if os.path.isfile("bigquery_credentials.dat"):
             os.rename("bigquery_credentials.dat", credentials_path)
 
-    credentials = load_user_account_credentials(
-        try_credentials,
-        project_id=project_id,
-        credentials_path=credentials_path,
-    )
+    credentials = None
+    if not reauth
+        credentials = load_user_account_credentials(
+            try_credentials,
+            project_id=project_id,
+            credentials_path=credentials_path,
+        )
 
     client_config = {
         "installed": {
@@ -178,7 +180,7 @@ def get_user_account_credentials(
         }
     }
 
-    if credentials is None or reauth:
+    if credentials is None:
         app_flow = InstalledAppFlow.from_client_config(
             client_config, scopes=SCOPES
         )

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -160,7 +160,7 @@ def get_user_account_credentials(
             os.rename("bigquery_credentials.dat", credentials_path)
 
     credentials = None
-    if not reauth
+    if not reauth:
         credentials = load_user_account_credentials(
             try_credentials,
             project_id=project_id,


### PR DESCRIPTION
If the credentials on disk are invalid, then `get_user_credentials()` may fail
before it can fetch fresh credentials.

Noticed first and fixed in pydata-google-auth package in
https://github.com/pydata/pydata-google-auth/commit/7ce7f3f822fbaea7cc73878f52c61f8b38109f36

Note about pydata-google-auth: eventually I'd like to move pandas-gbq
to use that package for auth, but since I'm not sure when I'll have that
package ready, I'm patching pandas-gbq, too.