### PR TITLE
ENH: Catch RefreshError in _try_credentials()

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,7 @@ Changelog
   This fixes a bug where pandas-gbq could not refresh credentials if the
   cached credentials were invalid, revoked, or expired, even when
   ``reauth=True``.
+- Catch RefreshError when trying credentials. (:issue:`226`)
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -297,6 +297,7 @@ def save_user_account_credentials(credentials, credentials_path):
 def _try_credentials(project_id, credentials):
     from google.cloud import bigquery
     import google.api_core.exceptions
+    import google.auth.exceptions
 
     if not credentials:
         return None
@@ -309,4 +310,10 @@ def _try_credentials(project_id, credentials):
         client.query("SELECT 1").result()
         return credentials
     except google.api_core.exceptions.GoogleAPIError:
+        return None
+    except google.auth.exceptions.RefreshError:
+        # Sometimes (such as on Travis) google-auth returns GCE credentials,
+        # but fetching the token for those credentials doesn't actually work.
+        # See:
+        # https://github.com/googleapis/google-auth-library-python/issues/287
         return None


### PR DESCRIPTION
Fixes the build errors on Travis, where GCE credentials are available but not actually useful.

Closes #226.