### PR TITLE
Allow newlines in data passed to to_gbq()

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+.. _changelog-0.7.1:
+
+0.7.1 / unreleased
+--------------------
+
 - Allow newlines in data passed to ``to_gbq``. (:issue:`180`)
 
 .. _changelog-0.7.0:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Allow newlines in data passed to ``to_gbq``. (:issue:`180`)
+
 .. _changelog-0.7.0:
 
 0.7.0 / 2018-10-19

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -61,6 +61,7 @@ def load_chunks(
     job_config = bigquery.LoadJobConfig()
     job_config.write_disposition = "WRITE_APPEND"
     job_config.source_format = "CSV"
+    job_config.allow_quoted_newlines = True
 
     if schema is None:
         schema = pandas_gbq.schema.generate_bq_schema(dataframe)

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -37,6 +37,18 @@ def test_encode_chunk_with_floats():
     assert "1.05153" in csv_string
 
 
+def test_encode_chunk_with_newlines():
+    """See: https://github.com/pydata/pandas-gbq/issues/180
+    """
+    df = pandas.DataFrame({"s": ["abcd", "ef\ngh", "ij\r\nkl"]})
+    csv_buffer = load.encode_chunk(df)
+    csv_bytes = csv_buffer.read()
+    csv_string = csv_bytes.decode("utf-8")
+    assert "abcd" in csv_string
+    assert '"ef\ngh"' in csv_string
+    assert '"ij\r\nkl"' in csv_string
+
+
 def test_encode_chunks_splits_dataframe():
     df = pandas.DataFrame(numpy.random.randn(6, 4), index=range(6))
     chunks = list(load.encode_chunks(df, chunksize=2))


### PR DESCRIPTION
Relates to #180.

I intended to include `\r\n` in the system test, but I found that something was stripping `\r` in the round trip:

```pytest
>       assert result_df.iloc[2,0] == "ij\r\nkl"
E       AssertionError: assert 'ij\nkl' == 'ij\r\nkl'
E         - ij
E         + ij
E         ?   +
E           kl
```

The unit test shows, I think, that we're sending the values correctly, so I didn't investigate further.