### PR TITLE
ENH: Add credentials argument to read_gbq and to_gbq.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,10 +1,25 @@
 Changelog
 =========
 
-.. _changelog-0.7.1:
+.. _changelog-0.8.0:
 
-0.7.1 / unreleased
+0.8.0 / unreleased
 --------------------
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+- **Deprecate** ``private_key`` parameter to :func:`pandas_gbq.read_gbq` and
+  :func:`pandas_gbq.to_gbq` in favor of new ``credentials`` argument. Instead,
+  create a credentials object using
+  :func:`google.oauth2.service_account.Credentials.from_service_account_info`
+  or
+  :func:`google.oauth2.service_account.Credentials.from_service_account_file`.
+  See the :doc:`authentication how-to guide <howto/authentication>` for
+  examples. (:issue:`161`, :issue:`TODO`)
+
+Enhancements
+~~~~~~~~~~~~
 
 - Allow newlines in data passed to ``to_gbq``. (:issue:`180`)
 

--- a/docs/source/howto/authentication.rst
+++ b/docs/source/howto/authentication.rst
@@ -20,6 +20,16 @@ key file.
 
 To use service account credentials, set the ``credentials`` parameter to the result of a call to:
 
+* :func:`google.oauth2.service_account.Credentials.from_service_account_file`,
+    which accepts a file path to the JSON file.
+
+    .. code:: python
+
+        credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+            'path/to/key.json',
+        )
+        df = pandas_gbq.read_gbq(sql, project_id="YOUR-PROJECT-ID", credentials=credentials)
+
 * :func:`google.oauth2.service_account.Credentials.from_service_account_info`,
     which accepts a dictionary corresponding to the JSON file contents.
 
@@ -38,16 +48,6 @@ To use service account credentials, set the ``credentials`` parameter to the res
                 "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
                 "client_x509_cert_url": "https://www.googleapis.com/...iam.gserviceaccount.com"
             },
-        )
-        df = pandas_gbq.read_gbq(sql, project_id="YOUR-PROJECT-ID", credentials=credentials)
-
-* :func:`google.oauth2.service_account.Credentials.from_service_account_file`,
-    which accepts a file path to the JSON file.
-
-    .. code:: python
-
-        credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-            'path/to/key.json',
         )
         df = pandas_gbq.read_gbq(sql, project_id="YOUR-PROJECT-ID", credentials=credentials)
 

--- a/docs/source/howto/authentication.rst
+++ b/docs/source/howto/authentication.rst
@@ -18,11 +18,38 @@ Create a service account key via the `service account key creation page
 the Google Cloud Platform Console. Select the JSON key type and download the
 key file.
 
-To use service account credentials, set the ``private_key`` parameter to one
-of:
+To use service account credentials, set the ``credentials`` parameter to the result of a call to:
 
-* A file path to the JSON file.
-* A string containing the JSON file contents.
+* :func:`google.oauth2.service_account.Credentials.from_service_account_info`,
+    which accepts a dictionary corresponding to the JSON file contents.
+
+    .. code:: python
+
+        credentials = google.oauth2.service_account.Credentials.from_service_account_info(
+            {
+                "type": "service_account",
+                "project_id": "YOUR-PROJECT-ID",
+                "private_key_id": "6747200734a1f2b9d8d62fc0b9414c5f2461db0e",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nM...I==\n-----END PRIVATE KEY-----\n",
+                "client_email": "service-account@YOUR-PROJECT-ID.iam.gserviceaccount.com",
+                "client_id": "12345678900001",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://accounts.google.com/o/oauth2/token",
+                "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                "client_x509_cert_url": "https://www.googleapis.com/...iam.gserviceaccount.com"
+            },
+        )
+        df = pandas_gbq.read_gbq(sql, project_id="YOUR-PROJECT-ID", credentials=credentials)
+
+* :func:`google.oauth2.service_account.Credentials.from_service_account_file`,
+    which accepts a file path to the JSON file.
+
+    .. code:: python
+
+        credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+            'path/to/key.json',
+        )
+        df = pandas_gbq.read_gbq(sql, project_id="YOUR-PROJECT-ID", credentials=credentials)
 
 See the `Getting started with authentication on Google Cloud Platform
 <https://cloud.google.com/docs/authentication/getting-started>`_ guide for


### PR DESCRIPTION
Deprecates private_key parameter.

Note: I didn't actually add a deprecation warning message yet because I don't know which version of pandas this change will get added to.

Towards #161 