### PR TITLE
CLN: Use `to_dataframe` to download query results.

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,16 @@
+# pandas-gbq benchmarks
+
+This directory contains a few scripts which are useful for performance
+testing the pandas-gbq library. Use cProfile to time the script and see
+details about where time is spent. To avoid timing how long BigQuery takes to
+execute a query, run the benchmark twice to ensure the results are cached.
+
+## `read_gbq`
+
+Read a small table (a few KB).
+
+    python -m cProfile --sort=cumtime read_gbq_small_results.py
+
+Read a large-ish table (100+ MB).
+
+    python -m cProfile --sort=cumtime read_gbq_large_results.py

--- a/benchmark/read_gbq_large_results.py
+++ b/benchmark/read_gbq_large_results.py
@@ -1,4 +1,3 @@
-
 import pandas_gbq
 
 # Select 163 MB worth of data, to time how long it takes to download large

--- a/benchmark/read_gbq_large_results.py
+++ b/benchmark/read_gbq_large_results.py
@@ -5,4 +5,5 @@ import pandas_gbq
 # result sets.
 df = pandas_gbq.read_gbq(
     "SELECT * FROM `bigquery-public-data.usa_names.usa_1910_2013`",
-    dialect="standard")
+    dialect="standard",
+)

--- a/benchmark/read_gbq_large_results.py
+++ b/benchmark/read_gbq_large_results.py
@@ -1,0 +1,8 @@
+
+import pandas_gbq
+
+# Select 163 MB worth of data, to time how long it takes to download large
+# result sets.
+df = pandas_gbq.read_gbq(
+    "SELECT * FROM `bigquery-public-data.usa_names.usa_1910_2013`",
+    dialect="standard")

--- a/benchmark/read_gbq_small_results.py
+++ b/benchmark/read_gbq_small_results.py
@@ -1,4 +1,3 @@
-
 import pandas_gbq
 
 # Select a few KB worth of data, to time downloading small result sets.

--- a/benchmark/read_gbq_small_results.py
+++ b/benchmark/read_gbq_small_results.py
@@ -4,4 +4,5 @@ import pandas_gbq
 # Select a few KB worth of data, to time downloading small result sets.
 df = pandas_gbq.read_gbq(
     "SELECT * FROM `bigquery-public-data.utility_us.country_code_iso`",
-    dialect="standard")
+    dialect="standard",
+)

--- a/benchmark/read_gbq_small_results.py
+++ b/benchmark/read_gbq_small_results.py
@@ -1,0 +1,7 @@
+
+import pandas_gbq
+
+# Select a few KB worth of data, to time downloading small result sets.
+df = pandas_gbq.read_gbq(
+    "SELECT * FROM `bigquery-public-data.utility_us.country_code_iso`",
+    dialect="standard")

--- a/ci/requirements-2.7.pip
+++ b/ci/requirements-2.7.pip
@@ -2,5 +2,5 @@ mock
 pandas==0.17.1
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
-google-cloud-bigquery==0.32.0
+google-cloud-bigquery==1.9.0
 pydata-google-auth==0.1.2

--- a/ci/requirements-3.5.pip
+++ b/ci/requirements-3.5.pip
@@ -1,5 +1,5 @@
 pandas==0.19.0
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
-google-cloud-bigquery==0.32.0
+google-cloud-bigquery==1.9.0
 pydata-google-auth==0.1.2

--- a/ci/requirements-3.6-0.20.1.conda
+++ b/ci/requirements-3.6-0.20.1.conda
@@ -1,6 +1,6 @@
 google-auth
 google-auth-oauthlib
-google-cloud-bigquery==0.32.0
+google-cloud-bigquery==1.9.0
 pytest
 pytest-cov
 codecov

--- a/ci/requirements-3.6-0.20.1.conda
+++ b/ci/requirements-3.6-0.20.1.conda
@@ -1,5 +1,4 @@
-google-auth
-google-auth-oauthlib
+pydata-google-auth
 google-cloud-bigquery==1.9.0
 pytest
 pytest-cov

--- a/ci/run_conda.sh
+++ b/ci/run_conda.sh
@@ -21,7 +21,7 @@ fi
 
 REQ="ci/requirements-${PYTHON}-${PANDAS}"
 conda install -q --file "$REQ.conda";
-python setup.py develop
+python setup.py develop --no-deps
 
 # Run the tests
 $DIR/run_tests.sh

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+.. _changelog-0.10.0:
+
+0.10.0 / TBD
+------------
+
+Dependency updates
+~~~~~~~~~~~~~~~~~~
+
+- Update the minimum version of ``google-cloud-bigquery`` to 1.9.0.
+  (:issue:`247`)
+
+Internal changes
+~~~~~~~~~~~~~~~~
+
+- Use ``to_dataframe()`` from ``google-cloud-bigquery`` in the ``read_gbq()``
+  function. (:issue:`247`)
+
+
 .. _changelog-0.9.0:
 
 0.9.0 / 2019-01-11

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,9 @@ Changelog
 0.10.0 / TBD
 ------------
 
+- ``read_gbq()`` converts BigQuery ``TIMESTAMP`` columns to the
+  timezone-aware ``datetime64`` ``dtype``. (:issue:`247`)
+
 Dependency updates
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,9 +6,6 @@ Changelog
 0.10.0 / TBD
 ------------
 
-- ``read_gbq()`` converts BigQuery ``TIMESTAMP`` columns to the
-  timezone-aware ``datetime64`` ``dtype``. (:issue:`247`)
-
 Dependency updates
 ~~~~~~~~~~~~~~~~~~
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -35,7 +35,7 @@ def _check_google_client_version():
         raise ImportError("Could not import pkg_resources (setuptools).")
 
     # https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/bigquery/CHANGELOG.md
-    bigquery_minimum_version = pkg_resources.parse_version("0.32.0")
+    bigquery_minimum_version = pkg_resources.parse_version("1.9.0")
     BIGQUERY_INSTALLED_VERSION = pkg_resources.get_distribution(
         "google-cloud-bigquery"
     ).parsed_version

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -679,10 +679,7 @@ def _cast_empty_df_dtypes(schema_fields, df):
             "DataFrame must be empty in order to cast non-nullsafe dtypes"
         )
 
-    dtype_map = {
-        "BOOLEAN": bool,
-        "INTEGER": np.int64,
-    }
+    dtype_map = {"BOOLEAN": bool, "INTEGER": np.int64}
 
     for field in schema_fields:
         column = str(field["name"])

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -646,7 +646,10 @@ def _bqschema_to_nullsafe_dtypes(schema_fields):
     # #missing-data-casting-rules-and-indexing
     dtype_map = {
         "FLOAT": np.dtype(float),
-        "TIMESTAMP": "datetime64[ns, UTC]",
+        # Even though TIMESTAMPs are timezone-aware in BigQuery, pandas doesn't
+        # support datetime64[ns, UTC] as dtype in DataFrame constructors. See:
+        # https://github.com/pandas-dev/pandas/issues/12513
+        "TIMESTAMP": "datetime64[ns]",
         "TIME": "datetime64[ns]",
         "DATE": "datetime64[ns]",
         "DATETIME": "datetime64[ns]",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ INSTALL_REQUIRES = [
     "pydata-google-auth",
     "google-auth",
     "google-auth-oauthlib",
-    "google-cloud-bigquery>=0.32.0",
+    "google-cloud-bigquery>=1.9.0",
 ]
 
 extras = {"tqdm": "tqdm>=4.23.0"}

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -589,7 +589,9 @@ class TestReadGBQIntegration(object):
             "is_bot": pandas.Series([], dtype=np.dtype(bool)),
             "ts": pandas.Series([], dtype="datetime64[ns, UTC]"),
         }
-        expected_result = DataFrame(empty_columns)
+        expected_result = DataFrame(
+            empty_columns, columns=["title", "id", "is_bot", "ts"]
+        )
         tm.assert_frame_equal(df, expected_result, check_index_type=False)
 
     def test_one_row_one_column(self, project_id):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -400,8 +400,7 @@ class TestReadGBQIntegration(object):
             dialect="legacy",
         )
         tm.assert_frame_equal(
-            df,
-            DataFrame({"null_timestamp": [NaT]}, dtype="datetime64[ns]"),
+            df, DataFrame({"null_timestamp": [NaT]}, dtype="datetime64[ns]")
         )
 
     def test_should_properly_handle_null_datetime(self, project_id):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -344,8 +344,7 @@ class TestReadGBQIntegration(object):
         tm.assert_frame_equal(
             df,
             DataFrame(
-                {"unix_epoch": ["1970-01-01T00:00:00"]},
-                dtype="datetime64[ns]",
+                {"unix_epoch": ["1970-01-01T00:00:00"]}, dtype="datetime64[ns]"
             ),
         )
 
@@ -360,11 +359,7 @@ class TestReadGBQIntegration(object):
         tm.assert_frame_equal(
             df,
             DataFrame(
-                {
-                    "valid_timestamp": [
-                        np.datetime64("2004-09-15T05:00:00")
-                    ]
-                }
+                {"valid_timestamp": [np.datetime64("2004-09-15T05:00:00")]}
             ),
         )
 

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -313,7 +313,7 @@ class TestReadGBQIntegration(object):
             df,
             DataFrame(
                 {"unix_epoch": ["1970-01-01T00:00:00.000000Z"]},
-                dtype="datetime64[ns, UTC]",
+                dtype="datetime64[ns]",
             ),
         )
 
@@ -329,7 +329,7 @@ class TestReadGBQIntegration(object):
             df,
             DataFrame(
                 {"valid_timestamp": ["2004-09-15T05:00:00.000000Z"]},
-                dtype="datetime64[ns, UTC]",
+                dtype="datetime64[ns]",
             ),
         )
 
@@ -367,7 +367,7 @@ class TestReadGBQIntegration(object):
         "expression, type_",
         [
             ("current_date()", "<M8[ns]"),
-            ("current_timestamp()", "datetime64[ns, UTC]"),
+            ("current_timestamp()", "datetime64[ns]"),
             ("current_datetime()", "<M8[ns]"),
             ("TRUE", bool),
             ("FALSE", bool),
@@ -401,7 +401,7 @@ class TestReadGBQIntegration(object):
         )
         tm.assert_frame_equal(
             df,
-            DataFrame({"null_timestamp": [NaT]}, dtype="datetime64[ns, UTC]"),
+            DataFrame({"null_timestamp": [NaT]}, dtype="datetime64[ns]"),
         )
 
     def test_should_properly_handle_null_datetime(self, project_id):
@@ -587,7 +587,7 @@ class TestReadGBQIntegration(object):
             "title": pandas.Series([], dtype=object),
             "id": pandas.Series([], dtype=np.dtype(int)),
             "is_bot": pandas.Series([], dtype=np.dtype(bool)),
-            "ts": pandas.Series([], dtype="datetime64[ns, UTC]"),
+            "ts": pandas.Series([], dtype="datetime64[ns]"),
         }
         expected_result = DataFrame(
             empty_columns, columns=["title", "id", "is_bot", "ts"]

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -6,11 +6,12 @@ from datetime import datetime
 
 import google.oauth2.service_account
 import numpy as np
+import pandas
 import pandas.util.testing as tm
-import pytest
-import pytz
 from pandas import DataFrame, NaT, compat
 from pandas.compat import range, u
+import pytest
+import pytz
 
 from pandas_gbq import gbq
 
@@ -311,12 +312,45 @@ class TestReadGBQIntegration(object):
         tm.assert_frame_equal(
             df,
             DataFrame(
-                {"unix_epoch": [np.datetime64("1970-01-01T00:00:00.000000Z")]}
+                {"unix_epoch": ["1970-01-01T00:00:00.000000Z"]},
+                dtype="datetime64[ns, UTC]",
             ),
         )
 
     def test_should_properly_handle_arbitrary_timestamp(self, project_id):
         query = 'SELECT TIMESTAMP("2004-09-15 05:00:00") AS valid_timestamp'
+        df = gbq.read_gbq(
+            query,
+            project_id=project_id,
+            credentials=self.credentials,
+            dialect="legacy",
+        )
+        tm.assert_frame_equal(
+            df,
+            DataFrame(
+                {"valid_timestamp": ["2004-09-15T05:00:00.000000Z"]},
+                dtype="datetime64[ns, UTC]",
+            ),
+        )
+
+    def test_should_properly_handle_datetime_unix_epoch(self, project_id):
+        query = 'SELECT DATETIME("1970-01-01 00:00:00") AS unix_epoch'
+        df = gbq.read_gbq(
+            query,
+            project_id=project_id,
+            credentials=self.credentials,
+            dialect="legacy",
+        )
+        tm.assert_frame_equal(
+            df,
+            DataFrame(
+                {"unix_epoch": ["1970-01-01T00:00:00.000000Z"]},
+                dtype="datetime64[ns]",
+            ),
+        )
+
+    def test_should_properly_handle_arbitrary_datetime(self, project_id):
+        query = 'SELECT DATETIME("2004-09-15 05:00:00") AS valid_timestamp'
         df = gbq.read_gbq(
             query,
             project_id=project_id,
@@ -338,7 +372,7 @@ class TestReadGBQIntegration(object):
         "expression, type_",
         [
             ("current_date()", "<M8[ns]"),
-            ("current_timestamp()", "<M8[ns]"),
+            ("current_timestamp()", "datetime64[ns, UTC]"),
             ("current_datetime()", "<M8[ns]"),
             ("TRUE", bool),
             ("FALSE", bool),
@@ -370,7 +404,20 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
             dialect="legacy",
         )
-        tm.assert_frame_equal(df, DataFrame({"null_timestamp": [NaT]}))
+        tm.assert_frame_equal(
+            df,
+            DataFrame({"null_timestamp": [NaT]}, dtype="datetime64[ns, UTC]"),
+        )
+
+    def test_should_properly_handle_null_datetime(self, project_id):
+        query = "SELECT CAST(NULL AS DATETIME) AS null_datetime"
+        df = gbq.read_gbq(
+            query,
+            project_id=project_id,
+            credentials=self.credentials,
+            dialect="standard",
+        )
+        tm.assert_frame_equal(df, DataFrame({"null_datetime": [NaT]}))
 
     def test_should_properly_handle_null_boolean(self, project_id):
         query = "SELECT BOOLEAN(NULL) AS null_boolean"
@@ -541,18 +588,13 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
             dialect="legacy",
         )
-        page_array = np.zeros(
-            (0,),
-            dtype=[
-                ("title", object),
-                ("id", np.dtype(int)),
-                ("is_bot", np.dtype(bool)),
-                ("ts", "M8[ns]"),
-            ],
-        )
-        expected_result = DataFrame(
-            page_array, columns=["title", "id", "is_bot", "ts"]
-        )
+        empty_columns = {
+            "title": pandas.Series([], dtype=object),
+            "id": pandas.Series([], dtype=object),
+            "is_bot": pandas.Series([], dtype=object),
+            "ts": pandas.Series([], dtype="datetime64[ns, UTC]"),
+        }
+        expected_result = DataFrame(empty_columns)
         tm.assert_frame_equal(df, expected_result, check_index_type=False)
 
     def test_one_row_one_column(self, project_id):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -590,8 +590,8 @@ class TestReadGBQIntegration(object):
         )
         empty_columns = {
             "title": pandas.Series([], dtype=object),
-            "id": pandas.Series([], dtype=object),
-            "is_bot": pandas.Series([], dtype=object),
+            "id": pandas.Series([], dtype=np.dtype(int)),
+            "is_bot": pandas.Series([], dtype=np.dtype(bool)),
             "ts": pandas.Series([], dtype="datetime64[ns, UTC]"),
         }
         expected_result = DataFrame(empty_columns)

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -344,7 +344,7 @@ class TestReadGBQIntegration(object):
         tm.assert_frame_equal(
             df,
             DataFrame(
-                {"unix_epoch": ["1970-01-01T00:00:00.000000Z"]},
+                {"unix_epoch": ["1970-01-01T00:00:00"]},
                 dtype="datetime64[ns]",
             ),
         )
@@ -362,7 +362,7 @@ class TestReadGBQIntegration(object):
             DataFrame(
                 {
                     "valid_timestamp": [
-                        np.datetime64("2004-09-15T05:00:00.000000Z")
+                        np.datetime64("2004-09-15T05:00:00")
                     ]
                 }
             ),

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -138,14 +138,6 @@ class TestGBQConnectorIntegration(object):
         bigquery_client = gbq_connector.get_client()
         assert bigquery_client is not None
 
-    def test_should_be_able_to_get_schema_from_query(self, gbq_connector):
-        schema, pages = gbq_connector.run_query("SELECT 1")
-        assert schema is not None
-
-    def test_should_be_able_to_get_results_from_query(self, gbq_connector):
-        schema, pages = gbq_connector.run_query("SELECT 1")
-        assert pages is not None
-
 
 def test_should_read(project, credentials):
     query = 'SELECT "PI" AS valid_string'

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -2,6 +2,7 @@
 
 import pandas.util.testing as tm
 import pytest
+import numpy
 from pandas import DataFrame
 from pandas.compat.numpy import np_datetime64_compat
 
@@ -64,26 +65,23 @@ def no_auth(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("input", "type_", "expected"),
+    ("type_", "expected"),
     [
-        (1, "INTEGER", int(1)),
-        (1, "FLOAT", float(1)),
-        pytest.param("false", "BOOLEAN", False, marks=pytest.mark.xfail),
-        pytest.param(
-            "0e9",
-            "TIMESTAMP",
-            np_datetime64_compat("1970-01-01T00:00:00Z"),
-            marks=pytest.mark.xfail,
-        ),
-        ("STRING", "STRING", "STRING"),
+        ("INTEGER", None),  # Can't handle NULL
+        ("BOOLEAN", None),  # Can't handle NULL
+        ("FLOAT", numpy.dtype(float)),
+        ("TIMESTAMP", "datetime64[ns, UTC]"),
+        ("DATETIME", "datetime64[ns]"),
     ],
 )
-def test_should_return_bigquery_correctly_typed(input, type_, expected):
-    result = gbq._parse_data(
-        dict(fields=[dict(name="x", type=type_, mode="NULLABLE")]),
-        rows=[[input]],
-    ).iloc[0, 0]
-    assert result == expected
+def test_should_return_bigquery_correctly_typed(type_, expected):
+    result = gbq._bqschema_to_dtypes(
+        [dict(name="x", type=type_, mode="NULLABLE")]
+    )
+    if not expected:
+        assert result == {}
+    else:
+        assert result == {"x": expected}
 
 
 def test_to_gbq_should_fail_if_invalid_table_name_passed():
@@ -261,21 +259,6 @@ def test_read_gbq_with_no_project_id_given_should_fail(monkeypatch):
 def test_read_gbq_with_inferred_project_id(monkeypatch):
     df = gbq.read_gbq("SELECT 1", dialect="standard")
     assert df is not None
-
-
-def test_that_parse_data_works_properly():
-    from google.cloud.bigquery.table import Row
-
-    test_schema = {
-        "fields": [{"mode": "NULLABLE", "name": "column_x", "type": "STRING"}]
-    }
-    field_to_index = {"column_x": 0}
-    values = ("row_value",)
-    test_page = [Row(values, field_to_index)]
-
-    test_output = gbq._parse_data(test_schema, test_page)
-    correct_output = DataFrame({"column_x": ["row_value"]})
-    tm.assert_frame_equal(test_output, correct_output)
 
 
 def test_read_gbq_with_invalid_private_key_json_should_fail():

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -75,7 +75,7 @@ def no_auth(monkeypatch):
     ],
 )
 def test_should_return_bigquery_correctly_typed(type_, expected):
-    result = gbq._bqschema_to_dtypes(
+    result = gbq._bqschema_to_nullsafe_dtypes(
         [dict(name="x", type=type_, mode="NULLABLE")]
     )
     if not expected:

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -4,7 +4,6 @@ import pandas.util.testing as tm
 import pytest
 import numpy
 from pandas import DataFrame
-from pandas.compat.numpy import np_datetime64_compat
 
 import pandas_gbq.exceptions
 from pandas_gbq import gbq

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -69,7 +69,7 @@ def no_auth(monkeypatch):
         ("INTEGER", None),  # Can't handle NULL
         ("BOOLEAN", None),  # Can't handle NULL
         ("FLOAT", numpy.dtype(float)),
-        ("TIMESTAMP", "datetime64[ns, UTC]"),
+        ("TIMESTAMP", "datetime64[ns]"),
         ("DATETIME", "datetime64[ns]"),
     ],
 )

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.filter_warnings(
 def min_bq_version():
     import pkg_resources
 
-    return pkg_resources.parse_version("0.32.0")
+    return pkg_resources.parse_version("1.9.0")
 
 
 def mock_none_credentials(*args, **kwargs):


### PR DESCRIPTION
This allows us to remove logic for parsing the schema and align with
google-cloud-bigquery.

Towards #149 

Note, I ran the profiler before and after. For some reason I got about an extra 20 seconds with this versus before (331 before, 352 after). I can't figure out why that would be since in both cases we're just looping over all the rows and constructing a dataframe. Maybe it was just a fluke of my work WiFi network?

In either case, this change will help us with https://github.com/pydata/pandas-gbq/issues/242 once I release the next version of `google-cloud-bigquery`. It'll also help us with https://github.com/pydata/pandas-gbq/issues/133 whenever the mystery faster API launches.