### PR TITLE
BUG: avoid load jobs for empty dataframes

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1053,6 +1053,11 @@ def to_gbq(
     else:
         table.create(table_id, table_schema)
 
+    if dataframe.empty:
+        # Create the table (if needed), but don't try to run a load job with an
+        # empty file. See: https://github.com/pydata/pandas-gbq/issues/237
+        return
+
     connector.load_data(
         dataframe,
         dataset_id,

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -931,7 +931,6 @@ class TestToGBQIntegration(object):
 
     def test_upload_empty_data(self, project_id):
         test_id = "data_with_0_rows"
-        test_size = 0
         df = DataFrame()
 
         gbq.to_gbq(
@@ -947,7 +946,6 @@ class TestToGBQIntegration(object):
 
     def test_upload_empty_data_with_schema(self, project_id):
         test_id = "data_with_0_rows"
-        test_size = 0
         df = DataFrame(
             {
                 "a": pandas.Series(dtype="int64"),

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -902,7 +902,9 @@ class TestToGBQIntegration(object):
         )
         self.destination_table = "{}.{}".format(random_dataset_id, TABLE_ID)
         self.credentials = credentials
-        self.bqclient = bigquery.Client(project=project, credentials=credentials)
+        self.bqclient = bigquery.Client(
+            project=project, credentials=credentials
+        )
 
     def test_upload_data(self, project_id):
         test_id = "1"
@@ -950,7 +952,7 @@ class TestToGBQIntegration(object):
             {
                 "a": pandas.Series(dtype="int64"),
                 "b": pandas.Series(dtype="object"),
-            },
+            }
         )
 
         gbq.to_gbq(

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -892,6 +892,8 @@ class TestReadGBQIntegration(object):
 class TestToGBQIntegration(object):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self, project, credentials, random_dataset_id):
+        from google.cloud import bigquery
+
         # - PER-TEST FIXTURES -
         # put here any instruction you want to be run *BEFORE* *EVERY* test is
         # executed.
@@ -900,6 +902,7 @@ class TestToGBQIntegration(object):
         )
         self.destination_table = "{}.{}".format(random_dataset_id, TABLE_ID)
         self.credentials = credentials
+        self.bqclient = bigquery.Client(project=project, credentials=credentials)
 
     def test_upload_data(self, project_id):
         test_id = "1"
@@ -936,15 +939,32 @@ class TestToGBQIntegration(object):
             credentials=self.credentials,
         )
 
-        result = gbq.read_gbq(
-            "SELECT COUNT(*) AS num_rows FROM {0}".format(
-                self.destination_table + test_id
-            ),
-            project_id=project_id,
-            credentials=self.credentials,
-            dialect="legacy",
+        table = self.bqclient.get_table(self.destination_table + test_id)
+        assert table.num_rows == 0
+        assert len(table.schema) == 0
+
+    def test_upload_empty_data_with_schema(self, project_id):
+        test_id = "data_with_0_rows"
+        test_size = 0
+        df = DataFrame(
+            {
+                "a": pandas.Series(dtype="int64"),
+                "b": pandas.Series(dtype="object"),
+            },
         )
-        assert result["num_rows"][0] == test_size
+
+        gbq.to_gbq(
+            df,
+            self.destination_table + test_id,
+            project_id,
+            credentials=self.credentials,
+        )
+
+        table = self.bqclient.get_table(self.destination_table + test_id)
+        assert table.num_rows == 0
+        schema = table.schema
+        assert schema[0].field_type == "INTEGER"
+        assert schema[1].field_type == "STRING"
 
     def test_upload_data_if_table_exists_fail(self, project_id):
         test_id = "2"


### PR DESCRIPTION
No reason to run a load job if there is no data to load. This avoids a
"Empty schema specified for the load job." error when the DataFrame also
contains no columns.

Closes #237.