### PR TITLE
Remove import sys in logging documentation example

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -20,7 +20,6 @@ more verbose logs, you can do something like:
 .. code-block:: ipython
 
    import logging
-   import sys
    logger = logging.getLogger('pandas_gbq')
    logger.setLevel(logging.DEBUG)
-   logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+   logger.addHandler(logging.StreamHandler())


### PR DESCRIPTION
The import of `sys` isn't necessary in the logging example, as `sys.stdout` is the default stream for `StreamHandler`. In the interest of keeping examples as minimal as possible I would suggest to remove references to `sys.stdout` and leave that to the `logging` documentation.