### PR TITLE
read project_id from credentials if available

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,8 @@ Enhancements
 - Allow ``table_schema`` in :func:`to_gbq` to contain only a subset of columns,
   with the rest being populated using the DataFrame dtypes (:issue:`218`) 
   (contributed by @johnpaton)
+- Read ``project_id`` in :func:`to_gbq` from provided ``credentials`` if
+  available (contributed by @daureg)
 
 .. _changelog-0.9.0:
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1007,9 +1007,13 @@ def to_gbq(
         raise NotFoundException(
             "Invalid Table Name. Should be of the form 'datasetId.tableId' "
         )
-    if project_id is None and credentials is not None and credentials.__class__.__name__.endswith("Credentials"):
+    has_credentials = (
+        credentials is not None
+        and credentials.__class__.__name__.endswith("Credentials")
+    )
+    if project_id is None and has_credentials:
         project_id = credentials.project_id
-    
+
     connector = GbqConnector(
         project_id,
         reauth=reauth,

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1007,7 +1007,9 @@ def to_gbq(
         raise NotFoundException(
             "Invalid Table Name. Should be of the form 'datasetId.tableId' "
         )
-
+    if project_id is None and credentials is not None and credentials.__class__.__name__.endswith("Credentials"):
+        project_id = credentials.project_id
+    
     connector = GbqConnector(
         project_id,
         reauth=reauth,

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -318,6 +318,11 @@ class GbqConnector(object):
         self.credentials = credentials
         default_project = None
 
+        # Service account credentials have a project associated with them.
+        # Prefer that project if none was supplied.
+        if self.project_id is None and hasattr(self.credentials, "project_id"):
+            self.project_id = credentials.project_id
+
         # Load credentials from cache.
         if not self.credentials:
             self.credentials = context.credentials
@@ -421,6 +426,7 @@ class GbqConnector(object):
                 query,
                 job_config=bigquery.QueryJobConfig.from_api_repr(job_config),
                 location=self.location,
+                project=self.project_id,
             )
             logger.debug("Query running...")
         except (RefreshError, ValueError):
@@ -1007,9 +1013,6 @@ def to_gbq(
         raise NotFoundException(
             "Invalid Table Name. Should be of the form 'datasetId.tableId' "
         )
-
-    if project_id is None and hasattr(credentials, "project_id"):
-        project_id = credentials.project_id
 
     connector = GbqConnector(
         project_id,

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1007,11 +1007,8 @@ def to_gbq(
         raise NotFoundException(
             "Invalid Table Name. Should be of the form 'datasetId.tableId' "
         )
-    has_credentials = (
-        credentials is not None
-        and credentials.__class__.__name__.endswith("Credentials")
-    )
-    if project_id is None and has_credentials:
+
+    if project_id is None and hasattr(credentials, "project_id"):
         project_id = credentials.project_id
 
     connector = GbqConnector(

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -47,24 +47,27 @@ def mock_get_credentials(*args, **kwargs):
     return mock_credentials, "default-project"
 
 
-def mock_get_service_account_credentials(*args, **kwargs):
+@pytest.fixture
+def mock_service_account_credentials():
     import google.oauth2.service_account
 
     mock_credentials = mock.create_autospec(
         google.oauth2.service_account.Credentials
     )
-    return mock_credentials, mock_credentials.project_id
+    return mock_credentials
 
 
-def mock_get_compute_engine_credentials(*args, **kwargs):
+@pytest.fixture
+def mock_compute_engine_credentials():
     import google.auth.compute_engine
 
     mock_credentials = mock.create_autospec(
         google.auth.compute_engine.Credentials
     )
-    return mock_credentials, None
+    return mock_credentials
 
 
+@pytest.fixture
 def mock_get_user_credentials(*args, **kwargs):
     import google.auth.credentials
 
@@ -115,45 +118,6 @@ def test_to_gbq_with_no_project_id_given_should_fail(monkeypatch):
 
     with pytest.raises(ValueError) as exception:
         gbq.to_gbq(DataFrame([[1]]), "dataset.tablename")
-    assert "Could not determine project ID" in str(exception)
-
-
-def test_to_gbq_read_projectid_from_service_account_credentials(
-    min_bq_version
-):
-    import pkg_resources
-
-    credentials, _ = mock_get_service_account_credentials()
-    pandas_version = pkg_resources.parse_version("0.24.0")
-    with mock.patch(
-        "pkg_resources.Distribution.parsed_version",
-        new_callable=mock.PropertyMock,
-    ) as mock_version:
-        mock_version.side_effect = [min_bq_version, pandas_version]
-        try:
-            gbq.to_gbq(
-                DataFrame([[1]]), "dataset.tablename", credentials=credentials
-            )
-        except gbq.TableCreationError:
-            pass
-
-
-def test_to_gbq_read_projectid_from_compute_engine_credentials(min_bq_version):
-    import pkg_resources
-
-    credentials, _ = mock_get_compute_engine_credentials()
-    pandas_version = pkg_resources.parse_version("0.24.0")
-    with mock.patch(
-        "pkg_resources.Distribution.parsed_version",
-        new_callable=mock.PropertyMock,
-    ) as mock_version, pytest.raises(ValueError) as exception:
-        mock_version.side_effect = [min_bq_version, pandas_version]
-        try:
-            gbq.to_gbq(
-                DataFrame([[1]]), "dataset.tablename", credentials=credentials
-            )
-        except gbq.TableCreationError:
-            pass
     assert "Could not determine project ID" in str(exception)
 
 
@@ -315,6 +279,37 @@ def test_read_gbq_with_no_project_id_given_should_fail(monkeypatch):
 def test_read_gbq_with_inferred_project_id(monkeypatch):
     df = gbq.read_gbq("SELECT 1", dialect="standard")
     assert df is not None
+
+
+def test_read_gbq_with_inferred_project_id_from_service_account_credentials(
+    mock_bigquery_client,
+    mock_service_account_credentials
+):
+    mock_service_account_credentials.project_id = "service_account_project_id"
+    df = gbq.read_gbq(
+        "SELECT 1",
+        dialect="standard",
+        credentials=mock_service_account_credentials,
+    )
+    assert df is not None
+    mock_bigquery_client.query.assert_called_once_with(
+        "SELECT 1",
+        job_config=mock.ANY,
+        location=None,
+        project="service_account_project_id"
+    )
+
+
+def test_read_gbq_without_inferred_project_id_from_compute_engine_credentials(
+    mock_compute_engine_credentials
+):
+    with pytest.raises(ValueError) as exception:
+        gbq.read_gbq(
+            "SELECT 1",
+            dialect="standard",
+            credentials=mock_compute_engine_credentials,
+        )
+    assert "Could not determine project ID" in str(exception)
 
 
 def test_read_gbq_with_invalid_private_key_json_should_fail():

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -282,8 +282,7 @@ def test_read_gbq_with_inferred_project_id(monkeypatch):
 
 
 def test_read_gbq_with_inferred_project_id_from_service_account_credentials(
-    mock_bigquery_client,
-    mock_service_account_credentials
+    mock_bigquery_client, mock_service_account_credentials
 ):
     mock_service_account_credentials.project_id = "service_account_project_id"
     df = gbq.read_gbq(
@@ -296,7 +295,7 @@ def test_read_gbq_with_inferred_project_id_from_service_account_credentials(
         "SELECT 1",
         job_config=mock.ANY,
         location=None,
-        project="service_account_project_id"
+        project="service_account_project_id",
     )
 
 

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -116,9 +116,11 @@ def test_to_gbq_with_no_project_id_given_should_fail(monkeypatch):
     with pytest.raises(ValueError) as exception:
         gbq.to_gbq(DataFrame([[1]]), "dataset.tablename")
     assert "Could not determine project ID" in str(exception)
-    
 
-def test_to_gbq_read_projectid_from_service_account_credentials(min_bq_version):
+
+def test_to_gbq_read_projectid_from_service_account_credentials(
+    min_bq_version
+):
     import pkg_resources
 
     credentials, _ = mock_get_service_account_credentials()
@@ -130,12 +132,11 @@ def test_to_gbq_read_projectid_from_service_account_credentials(min_bq_version):
         mock_version.side_effect = [min_bq_version, pandas_version]
         try:
             gbq.to_gbq(
-                DataFrame([[1]]),
-                "dataset.tablename",
-                credentials=credentials
+                DataFrame([[1]]), "dataset.tablename", credentials=credentials
             )
         except gbq.TableCreationError:
             pass
+
 
 def test_to_gbq_read_projectid_from_compute_engine_credentials(min_bq_version):
     import pkg_resources
@@ -149,9 +150,7 @@ def test_to_gbq_read_projectid_from_compute_engine_credentials(min_bq_version):
         mock_version.side_effect = [min_bq_version, pandas_version]
         try:
             gbq.to_gbq(
-                DataFrame([[1]]),
-                "dataset.tablename",
-                credentials=credentials
+                DataFrame([[1]]), "dataset.tablename", credentials=credentials
             )
         except gbq.TableCreationError:
             pass


### PR DESCRIPTION
it seems a bit redundant to have to specify both in the common case where the service account is used for a single project