### PR TITLE
TST: Use pandas.api.types functions for dtypes checks

### DIFF
--- a/ci/requirements-2.7.pip
+++ b/ci/requirements-2.7.pip
@@ -1,5 +1,5 @@
 mock
-pandas==0.17.1
+pandas==0.19.0
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
 google-cloud-bigquery==1.9.0

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ Dependency updates
 
 - Update the minimum version of ``google-cloud-bigquery`` to 1.9.0.
   (:issue:`247`)
+- Update the minimum version of ``pandas`` to 0.19.0. (:issue:`262`)
 
 Internal changes
 ~~~~~~~~~~~~~~~~
@@ -23,7 +24,7 @@ Internal changes
 Enhancements
 ~~~~~~~~~~~~
 - Allow ``table_schema`` in :func:`to_gbq` to contain only a subset of columns,
-  with the rest being populated using the DataFrame dtypes (:issue:`218`) 
+  with the rest being populated using the DataFrame dtypes (:issue:`218`)
   (contributed by @johnpaton)
 - Read ``project_id`` in :func:`to_gbq` from provided ``credentials`` if
   available (contributed by @daureg)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def readme():
 
 INSTALL_REQUIRES = [
     "setuptools",
-    "pandas",
+    "pandas>=0.19.0",
     "pydata-google-auth",
     "google-auth",
     "google-auth-oauthlib",

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import google.oauth2.service_account
 import numpy as np
 import pandas
+import pandas.api.types
 import pandas.util.testing as tm
 from pandas import DataFrame, NaT, compat
 from pandas.compat import range, u
@@ -364,16 +365,16 @@ class TestReadGBQIntegration(object):
         )
 
     @pytest.mark.parametrize(
-        "expression, type_",
+        "expression, is_expected_dtype",
         [
-            ("current_date()", "<M8[ns]"),
-            ("current_timestamp()", "datetime64[ns]"),
-            ("current_datetime()", "<M8[ns]"),
-            ("TRUE", bool),
-            ("FALSE", bool),
+            ("current_date()", pandas.api.types.is_datetime64_ns_dtype),
+            ("current_timestamp()", pandas.api.types.is_datetime64_ns_dtype),
+            ("current_datetime()", pandas.api.types.is_datetime64_ns_dtype),
+            ("TRUE", pandas.api.types.is_bool_dtype),
+            ("FALSE", pandas.api.types.is_bool_dtype),
         ],
     )
-    def test_return_correct_types(self, project_id, expression, type_):
+    def test_return_correct_types(self, project_id, expression, is_expected_dtype):
         """
         All type checks can be added to this function using additional
         parameters, rather than creating additional functions.
@@ -389,7 +390,7 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
             dialect="standard",
         )
-        assert df["_"].dtype == type_
+        assert is_expected_dtype(df["_"].dtype)
 
     def test_should_properly_handle_null_timestamp(self, project_id):
         query = "SELECT TIMESTAMP(NULL) AS null_timestamp"

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -374,7 +374,9 @@ class TestReadGBQIntegration(object):
             ("FALSE", pandas.api.types.is_bool_dtype),
         ],
     )
-    def test_return_correct_types(self, project_id, expression, is_expected_dtype):
+    def test_return_correct_types(
+        self, project_id, expression, is_expected_dtype
+    ):
         """
         All type checks can be added to this function using additional
         parameters, rather than creating additional functions.


### PR DESCRIPTION
This should make checking for expected dtypes more robust.

An attempt at tackling https://github.com/pydata/pandas-gbq/issues/261. Though I would love to be more precise about whether a `datetime64` comes back as timezone aware or not, the fact that the behavior changed in pandas 0.24.x makes such a precise test challenging.