### PR TITLE
CLN: Update the authentication credentials.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,11 @@ Changelog
 0.10.0 / TBD
 ------------
 
-- This fixes a bug where pandas-gbq could not upload an empty database. (:issue:`237`)
+- Fix a bug where pandas-gbq could not upload an empty DataFrame. (:issue:`237`)
+- Update the authentication credentials. **Note:** You may need to set
+  ``reauth=True`` in order to update your credentials to the most recent
+  version. This is required to use new functionality such as the BigQuery
+  Storage API. (:issue:`267`)
 
 Dependency updates
 ~~~~~~~~~~~~~~~~~~
@@ -23,7 +27,7 @@ Internal changes
 Enhancements
 ~~~~~~~~~~~~
 - Allow ``table_schema`` in :func:`to_gbq` to contain only a subset of columns,
-  with the rest being populated using the DataFrame dtypes (:issue:`218`) 
+  with the rest being populated using the DataFrame dtypes (:issue:`218`)
   (contributed by @johnpaton)
 - Read ``project_id`` in :func:`to_gbq` from provided ``credentials`` if
   available (contributed by @daureg)

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -17,8 +17,9 @@ CREDENTIALS_CACHE_FILENAME = "bigquery_credentials.dat"
 SCOPES = ["https://www.googleapis.com/auth/bigquery"]
 
 # The following constants are used for end-user authentication.
-# It identifies the application that is requesting permission to access the
-# BigQuery API on behalf of a G Suite or Gmail user.
+# It identifies (via credentials from the pandas-gbq-auth GCP project) the
+# application that is requesting permission to access the BigQuery API on
+# behalf of a G Suite or Gmail user.
 #
 # In a web application, the client secret would be kept secret, but this is not
 # possible for applications that are installed locally on an end-user's
@@ -26,9 +27,9 @@ SCOPES = ["https://www.googleapis.com/auth/bigquery"]
 #
 # See: https://cloud.google.com/docs/authentication/end-user for details.
 CLIENT_ID = (
-    "495642085510-k0tmvj2m941jhre2nbqka17vqpjfddtd.apps.googleusercontent.com"
+    "725825577420-unm2gnkiprugilg743tkbig250f4sfsj.apps.googleusercontent.com"
 )
-CLIENT_SECRET = "kOc9wMptUtxkcIFbtZCcrEAc"
+CLIENT_SECRET = "4hqze9yI8fxShls8eJWkeMdJ"
 
 
 def get_credentials(


### PR DESCRIPTION
These auth credentials for the browser authentication flow belong to the
pandas-gbq-auth GCP project. The reason for the fresh project is that
this allows us to explicitly enable APIs needed for new functionality,
such as the BigQuery Storage API.