### PR TITLE
ENH: Use tz-aware dtype for timestamp columns

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -33,11 +33,14 @@ Internal changes
 
 Enhancements
 ~~~~~~~~~~~~
+
 - Allow ``table_schema`` in :func:`to_gbq` to contain only a subset of columns,
   with the rest being populated using the DataFrame dtypes (:issue:`218`)
   (contributed by @johnpaton)
 - Read ``project_id`` in :func:`to_gbq` from provided ``credentials`` if
   available (contributed by @daureg)
+- ``read_gbq`` uses the timezone-aware ``DatetimeTZDtype(unit='ns',
+  tz='UTC')`` dtype for BigQuery ``TIMESTAMP`` columns. (:issue:`269`)
 
 .. _changelog-0.9.0:
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,12 @@ Changelog
   version. This is required to use new functionality such as the BigQuery
   Storage API. (:issue:`267`)
 
+Documentation
+~~~~~~~~~~~~~
+
+- Document :ref:`BigQuery data type to pandas dtype conversion
+  <reading-dtypes>` for ``read_gbq``. (:issue:`269`)
+
 Dependency updates
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/reading.rst
+++ b/docs/source/reading.rst
@@ -9,21 +9,32 @@ Suppose you want to load all data from an existing BigQuery table
 
 .. code-block:: python
 
-   # Insert your BigQuery Project ID Here
-   # Can be found in the Google web console
+   import pandas_gbq
+
+   # TODO: Set your BigQuery Project ID.
    projectid = "xxxxxxxx"
 
-   data_frame = read_gbq('SELECT * FROM test_dataset.test_table', projectid)
+   data_frame = pandas_gbq.read_gbq(
+       'SELECT * FROM `test_dataset.test_table`',
+       project_id=projectid)
 
+.. note::
+
+    A project ID is sometimes optional if it can be inferred during
+    authentication, but it is required when authenticating with user
+    credentials. You can find your project ID in the `Google Cloud console
+    <https://console.cloud.google.com>`__.
 
 You can define which column from BigQuery to use as an index in the
 destination DataFrame as well as a preferred column order as follows:
 
 .. code-block:: python
 
-   data_frame = read_gbq('SELECT * FROM test_dataset.test_table',
-                          index_col='index_column_name',
-                          col_order=['col1', 'col2', 'col3'], projectid)
+   data_frame = pandas_gbq.read_gbq(
+       'SELECT * FROM `test_dataset.test_table`',
+       project_id=projectid,
+       index_col='index_column_name',
+       col_order=['col1', 'col2', 'col3'])
 
 
 You can specify the query config as parameter to use additional options of
@@ -37,20 +48,45 @@ your job. For more information about query configuration parameters see `here
         "useQueryCache": False
       }
    }
-   data_frame = read_gbq('SELECT * FROM test_dataset.test_table',
-                          configuration=configuration, projectid)
+   data_frame = read_gbq(
+       'SELECT * FROM `test_dataset.test_table`',
+       project_id=projectid,
+       configuration=configuration)
 
 
-.. note::
+The ``dialect`` argument can be used to indicate whether to use
+BigQuery's ``'legacy'`` SQL or BigQuery's ``'standard'`` SQL (beta). The
+default value is ``'standard'`` For more information on BigQuery's standard
+SQL, see `BigQuery SQL Reference
+<https://cloud.google.com/bigquery/docs/reference/standard-sql/>`__
 
-   You can find your project id in the `Google developers console
-   <https://console.developers.google.com>`__.
+.. code-block:: python
+
+   data_frame = pandas_gbq.read_gbq(
+       'SELECT * FROM [test_dataset.test_table]',
+       project_id=projectid,
+       dialect='legacy')
 
 
-.. note::
+.. _reading-dtypes:
 
-    The ``dialect`` argument can be used to indicate whether to use BigQuery's ``'legacy'`` SQL
-    or BigQuery's ``'standard'`` SQL (beta). The default value is ``'legacy'``, though this will change
-    in a subsequent release to ``'standard'``. For more information
-    on BigQuery's standard SQL, see `BigQuery SQL Reference
-    <https://cloud.google.com/bigquery/sql-reference/>`__
+Inferring the DataFrame's dtypes
+--------------------------------
+
+The :func:`~pandas_gbq.read_gbq` method infers the pandas dtype for each column, based on the BigQuery table schema.
+
+================== =========================
+BigQuery Data Type dtype
+================== =========================
+FLOAT              float
+------------------ -------------------------
+TIMESTAMP          **pandas versions 0.24.0+**
+                     :class:`~pandas.DatetimeTZDtype` with ``unit='ns'`` and
+                     ``tz='UTC'``
+                   **Earlier versions**
+                     datetime64[ns]
+------------------ -------------------------
+DATETIME           datetime64[ns]
+TIME               datetime64[ns]
+DATE               datetime64[ns]
+================== =========================

--- a/docs/source/reading.rst
+++ b/docs/source/reading.rst
@@ -79,13 +79,7 @@ The :func:`~pandas_gbq.read_gbq` method infers the pandas dtype for each column,
 BigQuery Data Type dtype
 ================== =========================
 FLOAT              float
------------------- -------------------------
-TIMESTAMP          **pandas versions 0.24.0+**
-                     :class:`~pandas.DatetimeTZDtype` with ``unit='ns'`` and
-                     ``tz='UTC'``
-                   **Earlier versions**
-                     datetime64[ns]
------------------- -------------------------
+TIMESTAMP          :class:`~pandas.DatetimeTZDtype` with ``unit='ns'`` and ``tz='UTC'``
 DATETIME           datetime64[ns]
 TIME               datetime64[ns]
 DATE               datetime64[ns]

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -650,6 +650,9 @@ def _bqschema_to_nullsafe_dtypes(schema_fields):
     # See:
     # http://pandas.pydata.org/pandas-docs/dev/missing_data.html
     # #missing-data-casting-rules-and-indexing
+    #
+    # If you update this mapping, also update the table at
+    # `docs/source/reading.rst`.
     dtype_map = {
         "FLOAT": np.dtype(float),
         # Even though TIMESTAMPs are timezone-aware in BigQuery, pandas doesn't

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -329,9 +329,10 @@ class TestReadGBQIntegration(object):
             {"valid_timestamp": ["2004-09-15T05:00:00.000000Z"]},
             dtype="datetime64[ns]",
         )
-        expected["valid_timestamp"] = expected[
-            "valid_timestamp"
-        ].dt.tz_localize("UTC")
+        if expected["valid_timestamp"].dt.tz is None:
+            expected["valid_timestamp"] = expected[
+                "valid_timestamp"
+            ].dt.tz_localize("UTC")
         tm.assert_frame_equal(df, expected)
 
     def test_should_properly_handle_datetime_unix_epoch(self, project_id):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -310,13 +310,12 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
             dialect="legacy",
         )
-        tm.assert_frame_equal(
-            df,
-            DataFrame(
-                {"unix_epoch": ["1970-01-01T00:00:00.000000Z"]},
-                dtype="datetime64[ns]",
-            ),
+        expected = DataFrame(
+            {"unix_epoch": ["1970-01-01T00:00:00.000000Z"]},
+            dtype="datetime64[ns]",
         )
+        expected["unix_epoch"] = expected["unix_epoch"].dt.tz_localize("UTC")
+        tm.assert_frame_equal(df, expected)
 
     def test_should_properly_handle_arbitrary_timestamp(self, project_id):
         query = 'SELECT TIMESTAMP("2004-09-15 05:00:00") AS valid_timestamp'
@@ -326,13 +325,14 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
             dialect="legacy",
         )
-        tm.assert_frame_equal(
-            df,
-            DataFrame(
-                {"valid_timestamp": ["2004-09-15T05:00:00.000000Z"]},
-                dtype="datetime64[ns]",
-            ),
+        expected = DataFrame(
+            {"valid_timestamp": ["2004-09-15T05:00:00.000000Z"]},
+            dtype="datetime64[ns]",
         )
+        expected["valid_timestamp"] = expected[
+            "valid_timestamp"
+        ].dt.tz_localize("UTC")
+        tm.assert_frame_equal(df, expected)
 
     def test_should_properly_handle_datetime_unix_epoch(self, project_id):
         query = 'SELECT DATETIME("1970-01-01 00:00:00") AS unix_epoch'
@@ -368,7 +368,7 @@ class TestReadGBQIntegration(object):
         "expression, is_expected_dtype",
         [
             ("current_date()", pandas.api.types.is_datetime64_ns_dtype),
-            ("current_timestamp()", pandas.api.types.is_datetime64_ns_dtype),
+            ("current_timestamp()", pandas.api.types.is_datetime64tz_dtype),
             ("current_datetime()", pandas.api.types.is_datetime64_ns_dtype),
             ("TRUE", pandas.api.types.is_bool_dtype),
             ("FALSE", pandas.api.types.is_bool_dtype),
@@ -402,9 +402,11 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
             dialect="legacy",
         )
-        tm.assert_frame_equal(
-            df, DataFrame({"null_timestamp": [NaT]}, dtype="datetime64[ns]")
+        expected = DataFrame({"null_timestamp": [NaT]}, dtype="datetime64[ns]")
+        expected["null_timestamp"] = expected["null_timestamp"].dt.tz_localize(
+            "UTC"
         )
+        tm.assert_frame_equal(df, expected)
 
     def test_should_properly_handle_null_datetime(self, project_id):
         query = "SELECT CAST(NULL AS DATETIME) AS null_datetime"
@@ -594,6 +596,7 @@ class TestReadGBQIntegration(object):
         expected_result = DataFrame(
             empty_columns, columns=["title", "id", "is_bot", "ts"]
         )
+        expected_result["ts"] = expected_result["ts"].dt.tz_localize("UTC")
         tm.assert_frame_equal(df, expected_result, check_index_type=False)
 
     def test_one_row_one_column(self, project_id):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -314,7 +314,8 @@ class TestReadGBQIntegration(object):
             {"unix_epoch": ["1970-01-01T00:00:00.000000Z"]},
             dtype="datetime64[ns]",
         )
-        expected["unix_epoch"] = expected["unix_epoch"].dt.tz_localize("UTC")
+        if expected["unix_epoch"].dt.tz is None:
+            expected["unix_epoch"] = expected["unix_epoch"].dt.tz_localize("UTC")
         tm.assert_frame_equal(df, expected)
 
     def test_should_properly_handle_arbitrary_timestamp(self, project_id):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -315,7 +315,9 @@ class TestReadGBQIntegration(object):
             dtype="datetime64[ns]",
         )
         if expected["unix_epoch"].dt.tz is None:
-            expected["unix_epoch"] = expected["unix_epoch"].dt.tz_localize("UTC")
+            expected["unix_epoch"] = expected["unix_epoch"].dt.tz_localize(
+                "UTC"
+            )
         tm.assert_frame_equal(df, expected)
 
     def test_should_properly_handle_arbitrary_timestamp(self, project_id):

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -95,6 +95,8 @@ def no_auth(monkeypatch):
         ("INTEGER", None),  # Can't handle NULL
         ("BOOLEAN", None),  # Can't handle NULL
         ("FLOAT", numpy.dtype(float)),
+        # TIMESTAMP will be localized after DataFrame construction.
+        ("TIMESTAMP", "datetime64[ns]"),
         ("DATETIME", "datetime64[ns]"),
     ],
 )
@@ -106,16 +108,6 @@ def test_should_return_bigquery_correctly_typed(type_, expected):
         assert result == {}
     else:
         assert result == {"x": expected}
-
-
-def test_should_return_bigquery_correctly_typed_timestamp():
-    result = gbq._bqschema_to_nullsafe_dtypes(
-        [dict(name="x", type="TIMESTAMP", mode="NULLABLE")]
-    )
-    if pandas_installed_version < pkg_resources.parse_version("0.24.0"):
-        assert result == {"x": "datetime64[ns]"}
-    else:
-        assert result == {"x": "datetime64[ns, UTC]"}
 
 
 def test_to_gbq_should_fail_if_invalid_table_name_passed():

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -90,7 +90,7 @@ def no_auth(monkeypatch):
         ("INTEGER", None),  # Can't handle NULL
         ("BOOLEAN", None),  # Can't handle NULL
         ("FLOAT", numpy.dtype(float)),
-        ("TIMESTAMP", "datetime64[ns]"),
+        ("TIMESTAMP", "datetime64[ns, UTC]"),
         ("DATETIME", "datetime64[ns]"),
     ],
 )


### PR DESCRIPTION
Adds a table documenting the current behavior, including that pandas 0.24.0 stores as time zone aware dtype and earlier versions store naive. I could not figure out how to make 0.24.0+ store as a naive dtype (https://github.com/pydata/pandas-gbq/issues/261), nor could I figure out how to make earlier versions use time zone aware (https://github.com/pydata/pandas-gbq/pull/263)