### PR TITLE
CLN: Drop support for Python 2.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,6 @@
 version: 2
 jobs:
   # Pip
-  "pip-2.7":
-    docker:
-      - image: thekevjames/nox
-    steps:
-      - checkout
-      - run: ci/config_auth.sh
-      - run: nox -s unit-2.7 system-2.7
-
   "pip-3.5":
     docker:
       - image: thekevjames/nox
@@ -60,7 +52,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - "pip-2.7"
       - "pip-3.5"
       - "pip-3.6"
       - "pip-3.7"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include MANIFEST.in
 include README.rst
-include LICENSE.md
+include AUTHORS.md
+include LICENSE.txt
 include setup.py
 
 graft pandas_gbq

--- a/ci/requirements-2.7.pip
+++ b/ci/requirements-2.7.pip
@@ -1,6 +1,0 @@
-mock
-pandas==0.19.0
-google-auth==1.4.1
-google-auth-oauthlib==0.0.1
-google-cloud-bigquery==1.9.0
-pydata-google-auth==0.1.2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _changelog-0.11.0:
+
+0.11.0 / TBD
+------------
+
+- **Breaking Change:** Python 2 support has been dropped. This is to align
+  with the pandas package which dropped Python 2 support at the end of 2019.
+  (:issue:`268`)
+
 .. _changelog-0.10.0:
 
 0.10.0 / 2019-04-05

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,8 +10,8 @@ import shutil
 import nox
 
 
-supported_pythons = ["2.7", "3.5", "3.6", "3.7"]
-latest_python = "3.6"
+supported_pythons = ["3.5", "3.6", "3.7"]
+latest_python = "3.7"
 
 
 @nox.session
@@ -31,7 +31,7 @@ def blacken(session):
 
 @nox.session(python=supported_pythons)
 def unit(session):
-    session.install("mock", "pytest", "pytest-cov")
+    session.install("pytest", "pytest-cov")
     session.install("-e", ".")
     session.run(
         "pytest",

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -5,8 +5,6 @@ import logging
 import os
 import os.path
 
-import pandas.compat
-
 import pandas_gbq.exceptions
 
 logger = logging.getLogger(__name__)
@@ -72,9 +70,7 @@ def get_service_account_credentials(private_key):
                 "   ", "\n"
             )
 
-        if pandas.compat.PY3:
-            json_key["private_key"] = bytes(json_key["private_key"], "UTF-8")
-
+        json_key["private_key"] = bytes(json_key["private_key"], "UTF-8")
         credentials = Credentials.from_service_account_info(json_key)
         credentials = credentials.with_scopes(SCOPES)
 

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -21,7 +21,7 @@
 *   Build the package
 
         git clean -xfd
-        python setup.py register sdist bdist_wheel --universal
+        python setup.py register sdist bdist_wheel
 
 *   Upload to test PyPI
 

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,6 @@ setup(
         "Intended Audience :: Science/Research",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tests/system/test_auth.py
+++ b/tests/system/test_auth.py
@@ -1,9 +1,7 @@
 """System tests for fetching Google BigQuery credentials."""
 
-try:
-    import mock
-except ImportError:  # pragma: NO COVER
-    from unittest import mock
+from unittest import mock
+
 import pytest
 
 from pandas_gbq import auth

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -9,8 +9,7 @@ import numpy as np
 import pandas
 import pandas.api.types
 import pandas.util.testing as tm
-from pandas import DataFrame, NaT, compat
-from pandas.compat import range, u
+from pandas import DataFrame, NaT
 import pytest
 import pytz
 
@@ -447,13 +446,8 @@ class TestReadGBQIntegration(object):
         )
 
     def test_unicode_string_conversion_and_normalization(self, project_id):
-        correct_test_datatype = DataFrame({"unicode_string": [u("\xe9\xfc")]})
-
-        unicode_string = "\xc3\xa9\xc3\xbc"
-
-        if compat.PY3:
-            unicode_string = unicode_string.encode("latin-1").decode("utf8")
-
+        correct_test_datatype = DataFrame({"unicode_string": ["éü"]})
+        unicode_string = "éü"
         query = 'SELECT "{0}" AS unicode_string'.format(unicode_string)
 
         df = gbq.read_gbq(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -5,10 +5,7 @@ import os.path
 
 from pandas_gbq import auth
 
-try:
-    import mock
-except ImportError:  # pragma: NO COVER
-    from unittest import mock
+from unittest import mock
 
 
 def test_get_credentials_private_key_contents(monkeypatch):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-try:
-    import mock
-except ImportError:  # pragma: NO COVER
-    from unittest import mock
+from unittest import mock
 
 import numpy
 from pandas import DataFrame


### PR DESCRIPTION
The 0.10.0 package will be the latest version to support Python 2. This
aligns pandas-gbq with pandas, which dropped support for Python 2 at the
end of 2019.

Closes #268 