### PR TITLE
Ensure table_schema arg is not modified inplace

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -13,6 +13,7 @@ except ImportError:  # pragma: NO COVER
     bigquery_storage_v1beta1 = None
 
 from pandas_gbq.exceptions import AccessDenied
+import pandas_gbq.schema
 
 logger = logging.getLogger(__name__)
 
@@ -1269,12 +1270,7 @@ class _Table(GbqConnector):
         table_ref = self.client.dataset(self.dataset_id).table(table_id)
         table = Table(table_ref)
 
-        # Manually create the schema objects, adding NULLABLE mode
-        # as a workaround for
-        # https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4456
-        for field in schema["fields"]:
-            if "mode" not in field:
-                field["mode"] = "NULLABLE"
+        schema = pandas_gbq.schema.add_default_nullable_mode(schema)
 
         table.schema = [
             SchemaField.from_api_repr(field) for field in schema["fields"]

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -66,12 +66,7 @@ def load_chunks(
     if schema is None:
         schema = pandas_gbq.schema.generate_bq_schema(dataframe)
 
-    # Manually create the schema objects, adding NULLABLE mode
-    # as a workaround for
-    # https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4456
-    for field in schema["fields"]:
-        if "mode" not in field:
-            field["mode"] = "NULLABLE"
+    schema = pandas_gbq.schema.add_default_nullable_mode(schema)
 
     job_config.schema = [
         bigquery.SchemaField.from_api_repr(field) for field in schema["fields"]

--- a/pandas_gbq/schema.py
+++ b/pandas_gbq/schema.py
@@ -1,5 +1,7 @@
 """Helper methods for BigQuery schemas"""
 
+import copy
+
 
 def generate_bq_schema(dataframe, default_type="STRING"):
     """Given a passed dataframe, generate the associated Google BigQuery schema.
@@ -62,3 +64,16 @@ def update_schema(schema_old, schema_new):
             output_fields.append(field)
 
     return {"fields": output_fields}
+
+
+def add_default_nullable_mode(schema):
+    """Manually create the schema objects, adding NULLABLE mode."""
+    # Workaround for:
+    # https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4456
+    #
+    # Returns a copy rather than modifying the mutable arg,
+    # per Issue #277
+    result = copy.deepcopy(schema)
+    for field in result["fields"]:
+        field.setdefault("mode", "NULLABLE")
+    return result


### PR DESCRIPTION
Fixes #277.

If any dictionary entry in the `table_schema` arg did
not contain a "mode" key, a mode="NULLABLE" kv pair
would be created; because `schema.update_schema()`
returns an object with references to its mutable input,
this allows the argument to ultimately be modified
by the function rather than the caller.

This pattern was used in both gbq.py and load.py,
so it was refactored into a helper function in
schema.py, which now returns a modified *copy*.
Deepcopy is used because the input is a list of
dictionaries, so a shallow copy would be insufficient.