### PR TITLE
ENH: Add user-agent string when constructing BigQuery and BigQuery Storage API clients.

### DIFF
--- a/ci/requirements-3.6-0.20.1.conda
+++ b/ci/requirements-3.6-0.20.1.conda
@@ -1,5 +1,6 @@
 pydata-google-auth
 google-cloud-bigquery==1.9.0
+google-cloud-bigquery-storage==0.5.0
 pytest
 pytest-cov
 codecov

--- a/ci/requirements-3.6-0.20.1.conda
+++ b/ci/requirements-3.6-0.20.1.conda
@@ -1,8 +1,9 @@
-pydata-google-auth
-google-cloud-bigquery==1.9.0
-google-cloud-bigquery-storage==0.5.0
-pytest
-pytest-cov
 codecov
 coverage
+fastavro
 flake8
+google-cloud-bigquery==1.9.0
+google-cloud-bigquery-storage==0.5.0
+pydata-google-auth
+pytest
+pytest-cov

--- a/ci/requirements-3.7-NIGHTLY.conda
+++ b/ci/requirements-3.7-NIGHTLY.conda
@@ -1,5 +1,5 @@
 pydata-google-auth
-google-cloud-bigquery==1.10.0
+google-cloud-bigquery
 pytest
 pytest-cov
 codecov

--- a/ci/requirements-3.7-NIGHTLY.conda
+++ b/ci/requirements-3.7-NIGHTLY.conda
@@ -1,5 +1,6 @@
 pydata-google-auth
 google-cloud-bigquery
+google-cloud-bigquery-storage
 pytest
 pytest-cov
 codecov

--- a/ci/requirements-3.7.pip
+++ b/ci/requirements-3.7.pip
@@ -1,3 +1,3 @@
 pandas==0.24.0
-google-cloud-bigquery==1.9.0
+google-cloud-bigquery==1.12.0
 pydata-google-auth==0.1.2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,11 @@ Changelog
   with the pandas package which dropped Python 2 support at the end of 2019.
   (:issue:`268`)
 
+Internal changes
+~~~~~~~~~~~~~~~~
+
+- Populate ``user-agent`` with ``pandas`` version information. (:issue:`281`)
+
 .. _changelog-0.10.0:
 
 0.10.0 / 2019-04-05

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -18,6 +18,8 @@ import pandas_gbq.schema
 logger = logging.getLogger(__name__)
 
 BIGQUERY_INSTALLED_VERSION = None
+BIGQUERY_CLIENT_INFO_VERSION = "1.12.0"
+HAS_CLIENT_INFO = False
 SHOW_VERBOSE_DEPRECATION = False
 SHOW_PRIVATE_KEY_DEPRECATION = False
 PRIVATE_KEY_DEPRECATION_MESSAGE = (
@@ -34,7 +36,7 @@ except ImportError:
 
 
 def _check_google_client_version():
-    global BIGQUERY_INSTALLED_VERSION, SHOW_VERBOSE_DEPRECATION, SHOW_PRIVATE_KEY_DEPRECATION
+    global BIGQUERY_INSTALLED_VERSION, HAS_CLIENT_INFO, SHOW_VERBOSE_DEPRECATION, SHOW_PRIVATE_KEY_DEPRECATION
 
     try:
         import pkg_resources
@@ -44,9 +46,16 @@ def _check_google_client_version():
 
     # https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/bigquery/CHANGELOG.md
     bigquery_minimum_version = pkg_resources.parse_version("1.9.0")
+    bigquery_client_info_version = pkg_resources.parse_version(
+        BIGQUERY_CLIENT_INFO_VERSION
+    )
     BIGQUERY_INSTALLED_VERSION = pkg_resources.get_distribution(
         "google-cloud-bigquery"
     ).parsed_version
+
+    HAS_CLIENT_INFO = (
+        BIGQUERY_INSTALLED_VERSION >= bigquery_client_info_version
+    )
 
     if BIGQUERY_INSTALLED_VERSION < bigquery_minimum_version:
         raise ImportError(
@@ -392,6 +401,29 @@ class GbqConnector(object):
 
     def get_client(self):
         from google.cloud import bigquery
+        import pandas
+
+        try:
+            # This module was added in google-api-core 1.11.0.
+            # We don't have a hard requirement on that version, so only
+            # populate the client_info if available.
+            import google.api_core.client_info
+
+            client_info = google.api_core.client_info.ClientInfo(
+                user_agent="pandas-{}".format(pandas.__version__)
+            )
+        except ImportError:
+            client_info = None
+
+        # In addition to new enough version of google-api-core, a new enough
+        # version of google-cloud-bigquery is required to populate the
+        # client_info.
+        if HAS_CLIENT_INFO:
+            return bigquery.Client(
+                project=self.project_id,
+                credentials=self.credentials,
+                client_info=client_info,
+            )
 
         return bigquery.Client(
             project=self.project_id, credentials=self.credentials
@@ -747,12 +779,18 @@ def _make_bqstorage_client(use_bqstorage_api, credentials):
 
     if bigquery_storage_v1beta1 is None:
         raise ImportError(
-            "Install the google-cloud-bigquery-storage and fastavro packages "
-            "to use the BigQuery Storage API."
+            "Install the google-cloud-bigquery-storage and fastavro/pyarrow "
+            "packages to use the BigQuery Storage API."
         )
 
+    import google.api_core.gapic_v1.client_info
+    import pandas
+
+    client_info = google.api_core.gapic_v1.client_info.ClientInfo(
+        user_agent="pandas-{}".format(pandas.__version__)
+    )
     return bigquery_storage_v1beta1.BigQueryStorageClient(
-        credentials=credentials
+        credentials=credentials, client_info=client_info
     )
 
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -8,9 +8,9 @@ import numpy as np
 try:
     # The BigQuery Storage API client is an optional dependency. It is only
     # required when use_bqstorage_api=True.
-    from google.cloud import bigquery_storage_v1beta1
+    from google.cloud import bigquery_storage
 except ImportError:  # pragma: NO COVER
-    bigquery_storage_v1beta1 = None
+    bigquery_storage = None
 
 from pandas_gbq.exceptions import AccessDenied
 import pandas_gbq.schema
@@ -777,7 +777,7 @@ def _make_bqstorage_client(use_bqstorage_api, credentials):
     if not use_bqstorage_api:
         return None
 
-    if bigquery_storage_v1beta1 is None:
+    if bigquery_storage is None:
         raise ImportError(
             "Install the google-cloud-bigquery-storage and fastavro/pyarrow "
             "packages to use the BigQuery Storage API."
@@ -789,7 +789,7 @@ def _make_bqstorage_client(use_bqstorage_api, credentials):
     client_info = google.api_core.gapic_v1.client_info.ClientInfo(
         user_agent="pandas-{}".format(pandas.__version__)
     )
-    return bigquery_storage_v1beta1.BigQueryStorageClient(
+    return bigquery_storage.BigQueryStorageClient(
         credentials=credentials, client_info=client_info
     )
 

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -893,7 +893,7 @@ class TestReadGBQIntegration(object):
         assert df["max_year"][0] >= 2000
 
 
-@pytest.mark.skip(reason="large query for BQ Storage API tests")
+@pytest.mark.slow(reason="large query for BQ Storage API tests")
 def test_read_gbq_w_bqstorage_api(credentials):
     df = gbq.read_gbq(
         """

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -893,31 +893,14 @@ class TestReadGBQIntegration(object):
         assert df["max_year"][0] >= 2000
 
 
-@pytest.mark.slow(reason="large query for BQ Storage API tests")
 def test_read_gbq_w_bqstorage_api(credentials):
+    pytest.importorskip("google.cloud.bigquery_storage_v1beta1")
     df = gbq.read_gbq(
-        """
-        SELECT
-            dependency_name,
-            dependency_platform,
-            project_name,
-            project_id,
-            version_number,
-            version_id,
-            dependency_kind,
-            optional_dependency,
-            dependency_requirements,
-            dependency_project_id
-        FROM
-            `bigquery-public-data.libraries_io.dependencies`
-        WHERE
-            LOWER(dependency_platform) = 'npm'
-        LIMIT 2500000
-        """,
+        "SELECT * FROM `bigquery-public-data.usa_names.usa_1910_2013` LIMIT 5500000",
         use_bqstorage_api=True,
         credentials=credentials,
     )
-    assert len(df) == 2500000
+    assert len(df) == 5500000
 
 
 class TestToGBQIntegration(object):

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -72,8 +72,6 @@ def test_get_credentials_default_credentials(monkeypatch):
         )
 
     monkeypatch.setattr(google.auth, "default", mock_default_credentials)
-    mock_client = mock.create_autospec(google.cloud.bigquery.Client)
-    monkeypatch.setattr(google.cloud.bigquery, "Client", mock_client)
 
     credentials, project = auth.get_credentials()
     assert project == "default-project"


### PR DESCRIPTION
Since this was a relatively new addition to the BigQuery client library,
only populate the user-agent for BigQuery when recent-enough versions of
google-cloud-bigquery and google-api-core are installed.

Closes #281.