### PR TITLE
FIX: update minimum google-cloud-bigquery version to 1.11.0

### DIFF
--- a/ci/requirements-3.5.pip
+++ b/ci/requirements-3.5.pip
@@ -1,5 +1,5 @@
 pandas==0.19.0
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
-google-cloud-bigquery==1.9.0
+google-cloud-bigquery==1.11.0
 pydata-google-auth==0.1.2

--- a/ci/requirements-3.5.pip
+++ b/ci/requirements-3.5.pip
@@ -1,5 +1,5 @@
 pandas==0.19.0
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
-google-cloud-bigquery==1.11.0
+google-cloud-bigquery==1.11.1
 pydata-google-auth==0.1.2

--- a/ci/requirements-3.6-0.20.1.conda
+++ b/ci/requirements-3.6-0.20.1.conda
@@ -1,9 +1,8 @@
 codecov
 coverage
-fastavro
 flake8
-google-cloud-bigquery==1.9.0
-google-cloud-bigquery-storage==0.5.0
+google-cloud-bigquery==1.11.1
+google-cloud-bigquery-storage
 pydata-google-auth
 pytest
 pytest-cov

--- a/ci/requirements-3.6-0.20.1.conda
+++ b/ci/requirements-3.6-0.20.1.conda
@@ -1,5 +1,6 @@
 codecov
 coverage
+fastavro
 flake8
 google-cloud-bigquery==1.11.1
 google-cloud-bigquery-storage

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,7 +17,7 @@ Changelog
 Dependency updates
 ~~~~~~~~~~~~~~~~~~
 
-- Update the minimum version of ``google-cloud-bigquery`` to 1.11.0.
+- Update the minimum version of ``google-cloud-bigquery`` to 1.11.1.
   (:issue:`296`)
 
 Documentation

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,9 +10,15 @@ Changelog
   argument to limit the number of rows in the results DataFrame. Set
   ``max_results`` to 0 to ignore query outputs, such as for DML or DDL
   queries. (:issue:`102`)
+- Add ``progress_bar_type`` argument to :func:`~pandas_gbq.read_gbq()`. Use
+  this argument to display a progress bar when downloading data.
+  (:issue:`182`)
 
-- Add ``progress_bar_type`` argument to :func:`~pandas_gbq.read_gbq()`. Use this
-  argument to display a progress bar when downloading data. (:issue:`182`)
+Dependency updates
+~~~~~~~~~~~~~~~~~~
+
+- Update the minimum version of ``google-cloud-bigquery`` to 1.11.0.
+  (:issue:`296`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -45,7 +45,7 @@ def _check_google_client_version():
         raise ImportError("Could not import pkg_resources (setuptools).")
 
     # https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/bigquery/CHANGELOG.md
-    bigquery_minimum_version = pkg_resources.parse_version("1.9.0")
+    bigquery_minimum_version = pkg_resources.parse_version("1.11.0")
     bigquery_client_info_version = pkg_resources.parse_version(
         BIGQUERY_CLIENT_INFO_VERSION
     )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ INSTALL_REQUIRES = [
     "pydata-google-auth",
     "google-auth",
     "google-auth-oauthlib",
-    "google-cloud-bigquery>=1.11.0",
+    "google-cloud-bigquery>=1.11.1",
 ]
 
 extras = {"tqdm": "tqdm>=4.23.0"}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ INSTALL_REQUIRES = [
     "pydata-google-auth",
     "google-auth",
     "google-auth-oauthlib",
-    "google-cloud-bigquery>=1.9.0",
+    "google-cloud-bigquery>=1.11.0",
 ]
 
 extras = {"tqdm": "tqdm>=4.23.0"}

--- a/tests/system/test_auth.py
+++ b/tests/system/test_auth.py
@@ -74,7 +74,7 @@ def test_get_service_account_credentials_private_key_path(private_key_path):
 
 
 def test_get_service_account_credentials_private_key_contents(
-    private_key_contents
+    private_key_contents,
 ):
     from google.auth.credentials import Credentials
 

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -31,7 +31,7 @@ def _make_connector(project_id="some-project", **kwargs):
 def min_bq_version():
     import pkg_resources
 
-    return pkg_resources.parse_version("1.9.0")
+    return pkg_resources.parse_version("1.11.0")
 
 
 def mock_get_credentials_no_project(*args, **kwargs):
@@ -327,7 +327,7 @@ def test_read_gbq_with_inferred_project_id_from_service_account_credentials(
 
 
 def test_read_gbq_without_inferred_project_id_from_compute_engine_credentials(
-    mock_compute_engine_credentials
+    mock_compute_engine_credentials,
 ):
     with pytest.raises(ValueError, match="Could not determine project ID"):
         gbq.read_gbq(
@@ -406,7 +406,7 @@ def test_read_gbq_with_verbose_new_pandas_warns_deprecation(min_bq_version):
 
 
 def test_read_gbq_with_not_verbose_new_pandas_warns_deprecation(
-    min_bq_version
+    min_bq_version,
 ):
     import pkg_resources
 


### PR DESCRIPTION
Version 1.11.0 was the first version to include a `progress_bar_type`
argument. https://googleapis.dev/python/bigquery/latest/changelog.html#id51

Closes #296 