### PR TITLE
CLN: remove deprecated `private_key` auth logic

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _changelog-0.13.0:
+
+0.13.0 / 2019-12-12
+-------------------
+
+- Raise ``NotImplementedError`` when the deprecated ``private_key`` argument
+  is used. (:issue:`301`)
+
+
 .. _changelog-0.12.0:
 
 0.12.0 / 2019-11-25

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def unit(session):
 @nox.session
 def cover(session, python=latest_python):
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing", "--fail-under=74")
+    session.run("coverage", "report", "--show-missing", "--fail-under=73")
     session.run("coverage", "erase")
 
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -20,14 +20,6 @@ logger = logging.getLogger(__name__)
 BIGQUERY_INSTALLED_VERSION = None
 BIGQUERY_CLIENT_INFO_VERSION = "1.12.0"
 HAS_CLIENT_INFO = False
-SHOW_VERBOSE_DEPRECATION = False
-SHOW_PRIVATE_KEY_DEPRECATION = False
-PRIVATE_KEY_DEPRECATION_MESSAGE = (
-    "private_key is deprecated and will be removed in a future version."
-    "Use the credentials argument instead. See "
-    "https://pandas-gbq.readthedocs.io/en/latest/howto/authentication.html "
-    "for examples on using the credentials argument with service account keys."
-)
 
 try:
     import tqdm  # noqa
@@ -36,7 +28,7 @@ except ImportError:
 
 
 def _check_google_client_version():
-    global BIGQUERY_INSTALLED_VERSION, HAS_CLIENT_INFO, SHOW_VERBOSE_DEPRECATION, SHOW_PRIVATE_KEY_DEPRECATION
+    global BIGQUERY_INSTALLED_VERSION, HAS_CLIENT_INFO, SHOW_VERBOSE_DEPRECATION
 
     try:
         import pkg_resources
@@ -73,10 +65,6 @@ def _check_google_client_version():
     pandas_version_wo_verbosity = pkg_resources.parse_version("0.23.0")
     SHOW_VERBOSE_DEPRECATION = (
         pandas_installed_version >= pandas_version_wo_verbosity
-    )
-    pandas_version_with_credentials_arg = pkg_resources.parse_version("0.24.0")
-    SHOW_PRIVATE_KEY_DEPRECATION = (
-        pandas_installed_version >= pandas_version_with_credentials_arg
     )
 
 
@@ -1008,11 +996,6 @@ def read_gbq(
             stacklevel=2,
         )
 
-    if private_key is not None and SHOW_PRIVATE_KEY_DEPRECATION:
-        warnings.warn(
-            PRIVATE_KEY_DEPRECATION_MESSAGE, FutureWarning, stacklevel=2
-        )
-
     if dialect not in ("legacy", "standard"):
         raise ValueError("'{0}' is not valid for dialect".format(dialect))
 
@@ -1188,11 +1171,6 @@ def to_gbq(
             "verbosity",
             FutureWarning,
             stacklevel=1,
-        )
-
-    if private_key is not None and SHOW_PRIVATE_KEY_DEPRECATION:
-        warnings.warn(
-            PRIVATE_KEY_DEPRECATION_MESSAGE, FutureWarning, stacklevel=2
         )
 
     if if_exists not in ("fail", "replace", "append"):

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -939,27 +939,12 @@ def read_gbq(
         results.
 
         .. versionadded:: 0.12.0
-    verbose : None, deprecated
-        Deprecated in Pandas-GBQ 0.4.0. Use the `logging module
-        to adjust verbosity instead
-        <https://pandas-gbq.readthedocs.io/en/latest/intro.html#logging>`__.
-    private_key : str, deprecated
-        Deprecated in pandas-gbq version 0.8.0. Use the ``credentials``
-        parameter and
-        :func:`google.oauth2.service_account.Credentials.from_service_account_info`
-        or
-        :func:`google.oauth2.service_account.Credentials.from_service_account_file`
-        instead.
-
-        Service account private key in JSON format. Can be file path
-        or string contents. This is useful for remote server
-        authentication (eg. Jupyter/IPython notebook on remote host).
-
     progress_bar_type (Optional[str]):
-        If set, use the `tqdm <https://tqdm.github.io/>`_ library to
+        If set, use the `tqdm <https://tqdm.github.io/>`__ library to
         display a progress bar while the data downloads. Install the
         ``tqdm`` package to use this feature.
         Possible values of ``progress_bar_type`` include:
+
         ``None``
             No progress bar.
         ``'tqdm'``
@@ -971,6 +956,17 @@ def read_gbq(
         ``'tqdm_gui'``
             Use the :func:`tqdm.tqdm_gui` function to display a
             progress bar as a graphical dialog box.
+    verbose : None, deprecated
+        Deprecated in Pandas-GBQ 0.4.0. Use the `logging module
+        to adjust verbosity instead
+        <https://pandas-gbq.readthedocs.io/en/latest/intro.html#logging>`__.
+    private_key : str, deprecated
+        Deprecated in pandas-gbq version 0.8.0. Use the ``credentials``
+        parameter and
+        :func:`google.oauth2.service_account.Credentials.from_service_account_info`
+        or
+        :func:`google.oauth2.service_account.Credentials.from_service_account_file`
+        instead.
 
     Returns
     -------
@@ -1155,10 +1151,6 @@ def to_gbq(
         or
         :func:`google.oauth2.service_account.Credentials.from_service_account_file`
         instead.
-
-        Service account private key in JSON format. Can be file path
-        or string contents. This is useful for remote server
-        authentication (eg. Jupyter/IPython notebook on remote host).
     """
 
     _test_google_api_imports()

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -1,6 +1,7 @@
 """Helper methods for loading data into BigQuery"""
 
-import six
+import io
+
 from google.cloud import bigquery
 
 import pandas_gbq.schema
@@ -12,7 +13,7 @@ def encode_chunk(dataframe):
     Args:
       dataframe (pandas.DataFrame): A chunk of a dataframe to encode
     """
-    csv_buffer = six.StringIO()
+    csv_buffer = io.StringIO()
     dataframe.to_csv(
         csv_buffer,
         index=False,
@@ -25,10 +26,8 @@ def encode_chunk(dataframe):
     # Convert to a BytesIO buffer so that unicode text is properly handled.
     # See: https://github.com/pydata/pandas-gbq/issues/106
     body = csv_buffer.getvalue()
-    if isinstance(body, bytes):
-        body = body.decode("utf-8")
     body = body.encode("utf-8")
-    return six.BytesIO(body)
+    return io.BytesIO(body)
 
 
 def encode_chunks(dataframe, chunksize=None):

--- a/tests/system/test_auth.py
+++ b/tests/system/test_auth.py
@@ -1,5 +1,6 @@
 """System tests for fetching Google BigQuery credentials."""
 
+import os
 from unittest import mock
 
 import pytest
@@ -56,7 +57,8 @@ def _check_if_can_get_correct_default_credentials():
     return _try_credentials(project, credentials) is not None
 
 
-def test_should_be_able_to_get_valid_credentials(project_id):
+def test_should_be_able_to_get_valid_credentials(project_id, private_key_path):
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = private_key_path
     credentials, _ = auth.get_credentials(project_id=project_id)
     assert credentials.valid
 

--- a/tests/system/test_auth.py
+++ b/tests/system/test_auth.py
@@ -56,33 +56,9 @@ def _check_if_can_get_correct_default_credentials():
     return _try_credentials(project, credentials) is not None
 
 
-def test_should_be_able_to_get_valid_credentials(project_id, private_key_path):
-    credentials, _ = auth.get_credentials(
-        project_id=project_id, private_key=private_key_path
-    )
+def test_should_be_able_to_get_valid_credentials(project_id):
+    credentials, _ = auth.get_credentials(project_id=project_id)
     assert credentials.valid
-
-
-def test_get_service_account_credentials_private_key_path(private_key_path):
-    from google.auth.credentials import Credentials
-
-    credentials, project_id = auth.get_service_account_credentials(
-        private_key_path
-    )
-    assert isinstance(credentials, Credentials)
-    assert _try_credentials(project_id, credentials) is not None
-
-
-def test_get_service_account_credentials_private_key_contents(
-    private_key_contents,
-):
-    from google.auth.credentials import Credentials
-
-    credentials, project_id = auth.get_service_account_credentials(
-        private_key_contents
-    )
-    assert isinstance(credentials, Credentials)
-    assert _try_credentials(project_id, credentials) is not None
 
 
 @pytest.mark.local_auth

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -67,4 +67,6 @@ def test_get_credentials_cache_w_reauth():
     import pydata_google_auth.cache
 
     cache = auth.get_credentials_cache(True)
-    assert isinstance(cache, pydata_google_auth.cache.WriteOnlyCredentialsCache)
+    assert isinstance(
+        cache, pydata_google_auth.cache.WriteOnlyCredentialsCache
+    )

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -61,3 +61,10 @@ def test_get_credentials_load_user_no_default(monkeypatch):
     credentials, project = auth.get_credentials()
     assert project is None
     assert credentials is mock_user_credentials
+
+
+def test_get_credentials_cache_w_reauth():
+    import pydata_google_auth.cache
+
+    cache = auth.get_credentials_cache(True)
+    assert isinstance(cache, pydata_google_auth.cache.WriteOnlyCredentialsCache)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,28 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import json
-import os.path
+from unittest import mock
+
+import pytest
 
 from pandas_gbq import auth
 
-from unittest import mock
 
-
-def test_get_credentials_private_key_contents(monkeypatch):
-    from google.oauth2 import service_account
-
-    @classmethod
-    def from_service_account_info(cls, key_info):
-        mock_credentials = mock.create_autospec(cls)
-        mock_credentials.with_scopes.return_value = mock_credentials
-        mock_credentials.refresh.return_value = mock_credentials
-        return mock_credentials
-
-    monkeypatch.setattr(
-        service_account.Credentials,
-        "from_service_account_info",
-        from_service_account_info,
-    )
+def test_get_credentials_private_key_raises_notimplementederror(monkeypatch):
     private_key = json.dumps(
         {
             "private_key": "some_key",
@@ -30,34 +16,8 @@ def test_get_credentials_private_key_contents(monkeypatch):
             "project_id": "private-key-project",
         }
     )
-    credentials, project = auth.get_credentials(private_key=private_key)
-
-    assert credentials is not None
-    assert project == "private-key-project"
-
-
-def test_get_credentials_private_key_path(monkeypatch):
-    from google.oauth2 import service_account
-
-    @classmethod
-    def from_service_account_info(cls, key_info):
-        mock_credentials = mock.create_autospec(cls)
-        mock_credentials.with_scopes.return_value = mock_credentials
-        mock_credentials.refresh.return_value = mock_credentials
-        return mock_credentials
-
-    monkeypatch.setattr(
-        service_account.Credentials,
-        "from_service_account_info",
-        from_service_account_info,
-    )
-    private_key = os.path.join(
-        os.path.dirname(__file__), "..", "data", "dummy_key.json"
-    )
-    credentials, project = auth.get_credentials(private_key=private_key)
-
-    assert credentials is not None
-    assert project is None
+    with pytest.raises(NotImplementedError, match="private_key"):
+        auth.get_credentials(private_key=private_key)
 
 
 def test_get_credentials_default_credentials(monkeypatch):

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -224,15 +224,12 @@ def test_to_gbq_with_verbose_old_pandas_no_warnings(recwarn, min_bq_version):
 
 def test_to_gbq_with_private_key_raises_notimplementederror():
     with pytest.raises(NotImplementedError, match="private_key"):
-        try:
-            gbq.to_gbq(
-                DataFrame([[1]]),
-                "dataset.tablename",
-                project_id="my-project",
-                private_key="path/to/key.json",
-            )
-        except gbq.TableCreationError:
-            pass
+        gbq.to_gbq(
+            DataFrame([[1]]),
+            "dataset.tablename",
+            project_id="my-project",
+            private_key="path/to/key.json",
+        )
 
 
 def test_to_gbq_doesnt_run_query(


### PR DESCRIPTION
The argument will be removed in pandas 1.0. https://github.com/pandas-dev/pandas/pull/30200

Closes #301.