### PR TITLE
BUG: fix AttributeError with BQ Storage API to download empty results

### DIFF
--- a/ci/requirements-3.5.pip
+++ b/ci/requirements-3.5.pip
@@ -1,3 +1,4 @@
+numpy==1.13.3
 pandas==0.19.0
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 .. _changelog-0.13.1:
 
-0.13.1 / 2020-02-12
+0.13.1 / 2020-02-13
 -------------------
 
 - Fix ``AttributeError`` with BQ Storage API to download empty results.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _changelog-0.13.1:
+
+0.13.1 / 2020-02-12
+-------------------
+
+- Fix ``AttributeError`` with BQ Storage API to download empty results.
+  (:issue:`299`)
+
+
 .. _changelog-0.13.0:
 
 0.13.0 / 2019-12-12

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -8,12 +8,14 @@ import numpy as np
 try:
     # The BigQuery Storage API client is an optional dependency. It is only
     # required when use_bqstorage_api=True.
-    from google.cloud import bigquery_storage
+    from google.cloud import bigquery_storage_v1beta1
 except ImportError:  # pragma: NO COVER
-    bigquery_storage = None
+    bigquery_storage_v1beta1 = None
 
 from pandas_gbq.exceptions import AccessDenied
 import pandas_gbq.schema
+import pandas_gbq.timestamp
+
 
 logger = logging.getLogger(__name__)
 
@@ -561,7 +563,7 @@ class GbqConnector(object):
             df = _cast_empty_df_dtypes(schema_fields, df)
 
         # Ensure any TIMESTAMP columns are tz-aware.
-        df = _localize_df(schema_fields, df)
+        df = pandas_gbq.timestamp.localize_df(df, schema_fields)
 
         logger.debug("Got {} rows.\n".format(rows_iter.total_rows))
         return df
@@ -781,29 +783,11 @@ def _cast_empty_df_dtypes(schema_fields, df):
     return df
 
 
-def _localize_df(schema_fields, df):
-    """Localize any TIMESTAMP columns to tz-aware type.
-
-    In pandas versions before 0.24.0, DatetimeTZDtype cannot be used as the
-    dtype in Series/DataFrame construction, so localize those columns after
-    the DataFrame is constructed.
-    """
-    for field in schema_fields:
-        column = str(field["name"])
-        if field["mode"].upper() == "REPEATED":
-            continue
-
-        if field["type"].upper() == "TIMESTAMP" and df[column].dt.tz is None:
-            df[column] = df[column].dt.tz_localize("UTC")
-
-    return df
-
-
 def _make_bqstorage_client(use_bqstorage_api, credentials):
     if not use_bqstorage_api:
         return None
 
-    if bigquery_storage is None:
+    if bigquery_storage_v1beta1 is None:
         raise ImportError(
             "Install the google-cloud-bigquery-storage and fastavro/pyarrow "
             "packages to use the BigQuery Storage API."
@@ -815,7 +799,7 @@ def _make_bqstorage_client(use_bqstorage_api, credentials):
     client_info = google.api_core.gapic_v1.client_info.ClientInfo(
         user_agent="pandas-{}".format(pandas.__version__)
     )
-    return bigquery_storage.BigQueryStorageClient(
+    return bigquery_storage_v1beta1.BigQueryStorageClient(
         credentials=credentials, client_info=client_info
     )
 

--- a/pandas_gbq/timestamp.py
+++ b/pandas_gbq/timestamp.py
@@ -1,0 +1,40 @@
+"""Helpers for working with TIMESTAMP data type.
+
+Private module.
+"""
+
+
+def localize_df(df, schema_fields):
+    """Localize any TIMESTAMP columns to tz-aware type.
+
+    In pandas versions before 0.24.0, DatetimeTZDtype cannot be used as the
+    dtype in Series/DataFrame construction, so localize those columns after
+    the DataFrame is constructed.
+
+    Parameters
+    ----------
+    schema_fields: sequence of dict
+        BigQuery schema in parsed JSON data format.
+    df: pandaas.DataFrame
+        DataFrame in which to localize TIMESTAMP columns.
+
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with localized TIMESTAMP columns.
+    """
+    if len(df.index) == 0:
+        # If there are no rows, there is nothing to do.
+        # Fix for https://github.com/pydata/pandas-gbq/issues/299
+        return df
+
+    for field in schema_fields:
+        column = str(field["name"])
+        if "mode" in field and field["mode"].upper() == "REPEATED":
+            continue
+
+        if field["type"].upper() == "TIMESTAMP" and df[column].dt.tz is None:
+            df[column] = df[column].dt.tz_localize("UTC")
+
+    return df

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -19,6 +19,8 @@ def credentials(private_key_path):
 
 @pytest.fixture()
 def gbq_connector(project, credentials):
+    from pandas_gbq import gbq
+
     return gbq.GbqConnector(project, credentials=credentials)
 
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1,0 +1,77 @@
+
+import google.oauth2.service_account
+import pytest
+
+
+@pytest.fixture(params=["env"])
+def project(request, project_id):
+    if request.param == "env":
+        return project_id
+    elif request.param == "none":
+        return None
+
+
+@pytest.fixture()
+def credentials(private_key_path):
+    return google.oauth2.service_account.Credentials.from_service_account_file(
+        private_key_path
+    )
+
+
+@pytest.fixture()
+def gbq_connector(project, credentials):
+    return gbq.GbqConnector(project, credentials=credentials)
+
+
+@pytest.fixture()
+def random_dataset(bigquery_client, random_dataset_id):
+    from google.cloud import bigquery
+
+    dataset_ref = bigquery_client.dataset(random_dataset_id)
+    dataset = bigquery.Dataset(dataset_ref)
+    bigquery_client.create_dataset(dataset)
+    return dataset
+
+
+@pytest.fixture()
+def tokyo_dataset(bigquery_client, random_dataset_id):
+    from google.cloud import bigquery
+
+    dataset_ref = bigquery_client.dataset(random_dataset_id)
+    dataset = bigquery.Dataset(dataset_ref)
+    dataset.location = "asia-northeast1"
+    bigquery_client.create_dataset(dataset)
+    return random_dataset_id
+
+
+@pytest.fixture()
+def tokyo_table(bigquery_client, tokyo_dataset):
+    table_id = "tokyo_table"
+    # Create a random table using DDL.
+    # https://github.com/GoogleCloudPlatform/golang-samples/blob/2ab2c6b79a1ea3d71d8f91609b57a8fbde07ae5d/bigquery/snippets/snippet.go#L739
+    bigquery_client.query(
+        """CREATE TABLE {}.{}
+        AS SELECT
+          2000 + CAST(18 * RAND() as INT64) as year,
+          IF(RAND() > 0.5,"foo","bar") as token
+        FROM UNNEST(GENERATE_ARRAY(0,5,1)) as r
+        """.format(
+            tokyo_dataset, table_id
+        ),
+        location="asia-northeast1",
+    ).result()
+    return table_id
+
+
+@pytest.fixture()
+def gbq_dataset(project, credentials):
+    from pandas_gbq import gbq
+
+    return gbq._Dataset(project, credentials=credentials)
+
+
+@pytest.fixture()
+def gbq_table(project, credentials, random_dataset_id):
+    from pandas_gbq import gbq
+
+    return gbq._Table(project, random_dataset_id, credentials=credentials)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1,4 +1,3 @@
-
 import google.oauth2.service_account
 import pytest
 

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -525,9 +525,6 @@ class TestReadGBQIntegration(object):
             empty_columns,
             columns=["name", "number", "is_hurricane", "iso_time"],
         )
-        expected_result["iso_time"] = expected_result[
-            "iso_time"
-        ].dt.tz_localize("UTC")
         tm.assert_frame_equal(df, expected_result, check_index_type=False)
 
     def test_one_row_one_column(self, project_id):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import uuid
 from datetime import datetime
 
-import google.oauth2.service_account
 import numpy as np
 import pandas
 import pandas.api.types
@@ -26,76 +24,6 @@ def test_imports():
         raise ImportError("Could not import pkg_resources (setuptools).")
 
     gbq._test_google_api_imports()
-
-
-@pytest.fixture(params=["env"])
-def project(request, project_id):
-    if request.param == "env":
-        return project_id
-    elif request.param == "none":
-        return None
-
-
-@pytest.fixture()
-def credentials(private_key_path):
-    return google.oauth2.service_account.Credentials.from_service_account_file(
-        private_key_path
-    )
-
-
-@pytest.fixture()
-def gbq_connector(project, credentials):
-    return gbq.GbqConnector(project, credentials=credentials)
-
-
-@pytest.fixture()
-def random_dataset(bigquery_client, random_dataset_id):
-    from google.cloud import bigquery
-
-    dataset_ref = bigquery_client.dataset(random_dataset_id)
-    dataset = bigquery.Dataset(dataset_ref)
-    bigquery_client.create_dataset(dataset)
-    return dataset
-
-
-@pytest.fixture()
-def tokyo_dataset(bigquery_client, random_dataset_id):
-    from google.cloud import bigquery
-
-    dataset_ref = bigquery_client.dataset(random_dataset_id)
-    dataset = bigquery.Dataset(dataset_ref)
-    dataset.location = "asia-northeast1"
-    bigquery_client.create_dataset(dataset)
-    return random_dataset_id
-
-
-@pytest.fixture()
-def tokyo_table(bigquery_client, tokyo_dataset):
-    table_id = "tokyo_table"
-    # Create a random table using DDL.
-    # https://github.com/GoogleCloudPlatform/golang-samples/blob/2ab2c6b79a1ea3d71d8f91609b57a8fbde07ae5d/bigquery/snippets/snippet.go#L739
-    bigquery_client.query(
-        """CREATE TABLE {}.{}
-        AS SELECT
-          2000 + CAST(18 * RAND() as INT64) as year,
-          IF(RAND() > 0.5,"foo","bar") as token
-        FROM UNNEST(GENERATE_ARRAY(0,5,1)) as r
-        """.format(
-            tokyo_dataset, table_id
-        ),
-        location="asia-northeast1",
-    ).result()
-    return table_id
-
-
-@pytest.fixture()
-def gbq_dataset(project, credentials):
-    return gbq._Dataset(project, credentials=credentials)
-
-
-@pytest.fixture()
-def gbq_table(project, credentials, random_dataset_id):
-    return gbq._Table(project, random_dataset_id, credentials=credentials)
 
 
 def make_mixed_dataframe_v2(test_size):
@@ -896,43 +824,6 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
         )
         assert df["max_year"][0] >= 2000
-
-
-@pytest.mark.slow(reason="Large query for BQ Storage API tests.")
-def test_read_gbq_w_bqstorage_api(credentials, random_dataset):
-    pytest.importorskip("google.cloud.bigquery_storage")
-    df = gbq.read_gbq(
-        """
-        SELECT
-          total_amount,
-          passenger_count,
-          trip_distance
-        FROM `bigquery-public-data.new_york_taxi_trips.tlc_green_trips_2014`
-        -- Select non-null rows for no-copy conversion from Arrow to pandas.
-        WHERE total_amount IS NOT NULL
-          AND passenger_count IS NOT NULL
-          AND trip_distance IS NOT NULL
-        LIMIT 10000000
-        """,
-        use_bqstorage_api=True,
-        credentials=credentials,
-        configuration={
-            "query": {
-                "destinationTable": {
-                    "projectId": random_dataset.project,
-                    "datasetId": random_dataset.dataset_id,
-                    "tableId": "".join(
-                        [
-                            "test_read_gbq_w_bqstorage_api_",
-                            str(uuid.uuid4()).replace("-", "_"),
-                        ]
-                    ),
-                },
-                "writeDisposition": "WRITE_TRUNCATE",
-            }
-        },
-    )
-    assert len(df) == 10000000
 
 
 class TestToGBQIntegration(object):

--- a/tests/system/test_read_gbq_with_bqstorage.py
+++ b/tests/system/test_read_gbq_with_bqstorage.py
@@ -20,18 +20,17 @@ def method_under_test(credentials):
     "query_string",
     (
         ("SELECT * FROM (SELECT 1) WHERE TRUE = FALSE;"),
-        ("SELECT * FROM (SELECT TIMESTAMP('2020-02-11 16:33:32-06:00')) WHERE TRUE = FALSE;"),
-    )
+        (
+            "SELECT * FROM (SELECT TIMESTAMP('2020-02-11 16:33:32-06:00')) WHERE TRUE = FALSE;"
+        ),
+    ),
 )
 def test_empty_results(method_under_test, query_string):
     """Test with an empty dataframe.
 
     See: https://github.com/pydata/pandas-gbq/issues/299
     """
-    df = method_under_test(
-        query_string,
-        use_bqstorage_api=True,
-    )
+    df = method_under_test(query_string, use_bqstorage_api=True,)
     assert len(df.index) == 0
 
 

--- a/tests/system/test_read_gbq_with_bqstorage.py
+++ b/tests/system/test_read_gbq_with_bqstorage.py
@@ -1,0 +1,70 @@
+"""System tests for read_gbq using the BigQuery Storage API."""
+
+import functools
+import uuid
+
+import pytest
+
+
+pytest.importorskip("google.cloud.bigquery_storage_v1beta1")
+
+
+@pytest.fixture
+def method_under_test(credentials):
+    import pandas_gbq
+
+    return functools.partial(pandas_gbq.read_gbq, credentials=credentials)
+
+
+@pytest.mark.parametrize(
+    "query_string",
+    (
+        ("SELECT * FROM (SELECT 1) WHERE TRUE = FALSE;"),
+        ("SELECT * FROM (SELECT TIMESTAMP('2020-02-11 16:33:32-06:00')) WHERE TRUE = FALSE;"),
+    )
+)
+def test_empty_results(method_under_test, query_string):
+    """Test with an empty dataframe.
+
+    See: https://github.com/pydata/pandas-gbq/issues/299
+    """
+    df = method_under_test(
+        query_string,
+        use_bqstorage_api=True,
+    )
+    assert len(df.index) == 0
+
+
+@pytest.mark.slow(reason="Large query for BQ Storage API tests.")
+def test_large_results(random_dataset, method_under_test):
+    df = method_under_test(
+        """
+        SELECT
+          total_amount,
+          passenger_count,
+          trip_distance
+        FROM `bigquery-public-data.new_york_taxi_trips.tlc_green_trips_2014`
+        -- Select non-null rows for no-copy conversion from Arrow to pandas.
+        WHERE total_amount IS NOT NULL
+          AND passenger_count IS NOT NULL
+          AND trip_distance IS NOT NULL
+        LIMIT 10000000
+        """,
+        use_bqstorage_api=True,
+        configuration={
+            "query": {
+                "destinationTable": {
+                    "projectId": random_dataset.project,
+                    "datasetId": random_dataset.dataset_id,
+                    "tableId": "".join(
+                        [
+                            "test_read_gbq_w_bqstorage_api_",
+                            str(uuid.uuid4()).replace("-", "_"),
+                        ]
+                    ),
+                },
+                "writeDisposition": "WRITE_TRUNCATE",
+            }
+        },
+    )
+    assert len(df) == 10000000

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -17,8 +17,8 @@ def test_localize_df_with_empty_dataframe(module_under_test):
     df = pandas.DataFrame({"timestamp_col": [], "other_col": []})
     original = df.copy()
     bq_schema = [
-        {"name": "timestamp_col", "type": "TIMESTAMP",},
-        {"name": "other_col", "type": "STRING",},
+        {"name": "timestamp_col", "type": "TIMESTAMP"},
+        {"name": "other_col", "type": "STRING"},
     ]
 
     localized = module_under_test.localize_df(df, bq_schema)
@@ -34,8 +34,8 @@ def test_localize_df_with_no_timestamp_columns(module_under_test):
     )
     original = df.copy()
     bq_schema = [
-        {"name": "integer_col", "type": "INTEGER",},
-        {"name": "float_col", "type": "FLOAT",},
+        {"name": "integer_col", "type": "INTEGER"},
+        {"name": "float_col", "type": "FLOAT"},
     ]
 
     localized = module_under_test.localize_df(df, bq_schema)
@@ -63,9 +63,9 @@ def test_localize_df_with_timestamp_column(module_under_test):
     expected = df.copy()
     expected["timestamp_col"] = df["timestamp_col"].dt.tz_localize("UTC")
     bq_schema = [
-        {"name": "integer_col", "type": "INTEGER",},
-        {"name": "timestamp_col", "type": "TIMESTAMP",},
-        {"name": "float_col", "type": "FLOAT",},
+        {"name": "integer_col", "type": "INTEGER"},
+        {"name": "timestamp_col", "type": "TIMESTAMP"},
+        {"name": "float_col", "type": "FLOAT"},
     ]
 
     localized = module_under_test.localize_df(df, bq_schema)

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -17,14 +17,8 @@ def test_localize_df_with_empty_dataframe(module_under_test):
     df = pandas.DataFrame({"timestamp_col": [], "other_col": []})
     original = df.copy()
     bq_schema = [
-        {
-            "name": "timestamp_col",
-            "type": "TIMESTAMP",
-        },
-        {
-            "name": "other_col",
-            "type": "STRING",
-        },
+        {"name": "timestamp_col", "type": "TIMESTAMP",},
+        {"name": "other_col", "type": "STRING",},
     ]
 
     localized = module_under_test.localize_df(df, bq_schema)
@@ -35,17 +29,13 @@ def test_localize_df_with_empty_dataframe(module_under_test):
 
 
 def test_localize_df_with_no_timestamp_columns(module_under_test):
-    df = pandas.DataFrame({"integer_col": [1, 2, 3], "float_col": [0.1, 0.2, 0.3]})
+    df = pandas.DataFrame(
+        {"integer_col": [1, 2, 3], "float_col": [0.1, 0.2, 0.3]}
+    )
     original = df.copy()
     bq_schema = [
-        {
-            "name": "integer_col",
-            "type": "INTEGER",
-        },
-        {
-            "name": "float_col",
-            "type": "FLOAT",
-        },
+        {"name": "integer_col", "type": "INTEGER",},
+        {"name": "float_col", "type": "FLOAT",},
     ]
 
     localized = module_under_test.localize_df(df, bq_schema)
@@ -73,18 +63,9 @@ def test_localize_df_with_timestamp_column(module_under_test):
     expected = df.copy()
     expected["timestamp_col"] = df["timestamp_col"].dt.tz_localize("UTC")
     bq_schema = [
-        {
-            "name": "integer_col",
-            "type": "INTEGER",
-        },
-        {
-            "name": "timestamp_col",
-            "type": "TIMESTAMP",
-        },
-        {
-            "name": "float_col",
-            "type": "FLOAT",
-        },
+        {"name": "integer_col", "type": "INTEGER",},
+        {"name": "timestamp_col", "type": "TIMESTAMP",},
+        {"name": "float_col", "type": "FLOAT",},
     ]
 
     localized = module_under_test.localize_df(df, bq_schema)

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -1,0 +1,91 @@
+"""Unit tests for TIMESTAMP data type helpers."""
+
+import pandas
+import pandas.testing
+
+import pytest
+
+
+@pytest.fixture
+def module_under_test():
+    from pandas_gbq import timestamp
+
+    return timestamp
+
+
+def test_localize_df_with_empty_dataframe(module_under_test):
+    df = pandas.DataFrame({"timestamp_col": [], "other_col": []})
+    original = df.copy()
+    bq_schema = [
+        {
+            "name": "timestamp_col",
+            "type": "TIMESTAMP",
+        },
+        {
+            "name": "other_col",
+            "type": "STRING",
+        },
+    ]
+
+    localized = module_under_test.localize_df(df, bq_schema)
+
+    # Empty DataFrames should be unchanged.
+    assert localized is df
+    pandas.testing.assert_frame_equal(localized, original)
+
+
+def test_localize_df_with_no_timestamp_columns(module_under_test):
+    df = pandas.DataFrame({"integer_col": [1, 2, 3], "float_col": [0.1, 0.2, 0.3]})
+    original = df.copy()
+    bq_schema = [
+        {
+            "name": "integer_col",
+            "type": "INTEGER",
+        },
+        {
+            "name": "float_col",
+            "type": "FLOAT",
+        },
+    ]
+
+    localized = module_under_test.localize_df(df, bq_schema)
+
+    # DataFrames with no TIMESTAMP columns should be unchanged.
+    assert localized is df
+    pandas.testing.assert_frame_equal(localized, original)
+
+
+def test_localize_df_with_timestamp_column(module_under_test):
+    df = pandas.DataFrame(
+        {
+            "integer_col": [1, 2, 3],
+            "timestamp_col": pandas.Series(
+                [
+                    "2011-01-01 01:02:03",
+                    "2012-02-02 04:05:06",
+                    "2013-03-03 07:08:09",
+                ],
+                dtype="datetime64[ns]",
+            ),
+            "float_col": [0.1, 0.2, 0.3],
+        }
+    )
+    expected = df.copy()
+    expected["timestamp_col"] = df["timestamp_col"].dt.tz_localize("UTC")
+    bq_schema = [
+        {
+            "name": "integer_col",
+            "type": "INTEGER",
+        },
+        {
+            "name": "timestamp_col",
+            "type": "TIMESTAMP",
+        },
+        {
+            "name": "float_col",
+            "type": "FLOAT",
+        },
+    ]
+
+    localized = module_under_test.localize_df(df, bq_schema)
+    pandas.testing.assert_frame_equal(localized, expected)


### PR DESCRIPTION
Closes #299

**Also:**

* Refactors timestamp helpers to their own file to help reduce the size of the gbq module.
* Use `bigquery_storage_v1beta1` module to avoid breaking when `bigquery_storage_v1beta2` is released with breaking changes.

**TODO:**

- [x] Add tests to reproduce the issue.
- [x] Fix the issue.
- [x] Add to changelog.