### PR TITLE
TST: use larger query for timeout test

### DIFF
--- a/ci/requirements-3.5.pip
+++ b/ci/requirements-3.5.pip
@@ -1,3 +1,4 @@
+numpy==1.13.3
 pandas==0.19.0
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1

--- a/ci/run_conda.sh
+++ b/ci/run_conda.sh
@@ -11,6 +11,9 @@ conda update -q conda
 conda info -a
 conda create -q -n test-environment python=$PYTHON
 source activate test-environment
+REQ="ci/requirements-${PYTHON}-${PANDAS}"
+conda install -q --file "$REQ.conda";
+
 if [[ "$PANDAS" == "NIGHTLY" ]]; then
   conda install -q numpy pytz python-dateutil;
   PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com";
@@ -19,8 +22,6 @@ else
   conda install -q pandas=$PANDAS;
 fi
 
-REQ="ci/requirements-${PYTHON}-${PANDAS}"
-conda install -q --file "$REQ.conda";
 python setup.py develop --no-deps
 
 # Run the tests

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -480,7 +480,8 @@ class GbqConnector(object):
         while query_reply.state != "DONE":
             self.log_elapsed_seconds("  Elapsed", "s. Waiting...")
 
-            timeout_ms = job_config["query"].get("timeoutMs")
+            timeout_ms = job_config.get("jobTimeoutMs") or job_config["query"].get("timeoutMs")
+            timeout_ms = int(timeout_ms)
             if timeout_ms and timeout_ms < self.get_elapsed_seconds() * 1000:
                 raise QueryTimeout("Query timeout: {} ms".format(timeout_ms))
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -480,8 +480,10 @@ class GbqConnector(object):
         while query_reply.state != "DONE":
             self.log_elapsed_seconds("  Elapsed", "s. Waiting...")
 
-            timeout_ms = job_config.get("jobTimeoutMs") or job_config["query"].get("timeoutMs")
-            timeout_ms = int(timeout_ms)
+            timeout_ms = job_config.get("jobTimeoutMs") or job_config[
+                "query"
+            ].get("timeoutMs")
+            timeout_ms = int(timeout_ms) if timeout_ms else None
             if timeout_ms and timeout_ms < self.get_elapsed_seconds() * 1000:
                 raise QueryTimeout("Query timeout: {} ms".format(timeout_ms))
 

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -772,17 +772,33 @@ class TestReadGBQIntegration(object):
             )
 
     def test_timeout_configuration(self, project_id):
-        sql_statement = "SELECT 1"
-        config = {"query": {"timeoutMs": 1}}
-        # Test that QueryTimeout error raises
-        with pytest.raises(gbq.QueryTimeout):
-            gbq.read_gbq(
-                sql_statement,
-                project_id=project_id,
-                credentials=self.credentials,
-                configuration=config,
-                dialect="legacy",
-            )
+        sql_statement = """
+        SELECT
+          SUM(bottles_sold) total_bottles,
+          UPPER(category_name) category_name,
+          magnitude,
+          liquor.zip_code zip_code
+        FROM `bigquery-public-data.iowa_liquor_sales.sales` liquor
+        JOIN `bigquery-public-data.geo_us_boundaries.zip_codes` zip_codes
+        ON liquor.zip_code = zip_codes.zip_code
+        JOIN `bigquery-public-data.noaa_historic_severe_storms.tornado_paths` tornados
+        ON liquor.date = tornados.storm_date
+        WHERE ST_INTERSECTS(tornado_path_geom, zip_code_geom)
+        GROUP BY category_name, magnitude, zip_code
+        ORDER BY magnitude ASC, total_bottles DESC
+        """
+        configs = [
+            {"query": {"useQueryCache": False, "timeoutMs": 1}},
+            {"query": {"useQueryCache": False}, "jobTimeoutMs": 1},
+        ]
+        for config in configs:
+            with pytest.raises(gbq.QueryTimeout):
+                gbq.read_gbq(
+                    sql_statement,
+                    project_id=project_id,
+                    credentials=self.credentials,
+                    configuration=config,
+                )
 
     def test_query_response_bytes(self):
         assert self.gbq_connector.sizeof_fmt(999) == "999.0 B"

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -211,7 +211,10 @@ class TestReadGBQIntegration(object):
             credentials=self.credentials,
             dialect="legacy",
         )
-        tm.assert_frame_equal(df, DataFrame({"null_integer": [None]}))
+        tm.assert_frame_equal(
+            df,
+            DataFrame({"null_integer": pandas.Series([None], dtype="object")}),
+        )
 
     def test_should_properly_handle_valid_floats(self, project_id):
         from math import pi


### PR DESCRIPTION
Also, allow jobTimeoutMs, as that is the name for the backend parameter.