### PR TITLE
BUG: include needed "extras" from google-cloud-bigquery package

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _changelog-0.13.3:
+
+0.13.3 / 2020-09-30
+-------------------
+
+- Include needed "extras" from ``google-cloud-bigquery`` package as
+  dependencies. Exclude incompatible 2.0 version. (:issue:`324`, :issue:`329`)
+
+
 .. _changelog-0.13.2:
 
 0.13.2 / 2020-05-14

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ INSTALL_REQUIRES = [
     "pydata-google-auth",
     "google-auth",
     "google-auth-oauthlib",
-    "google-cloud-bigquery>=1.11.1",
+    "google-cloud-bigquery[bqstorage,pandas]>=1.11.1,<2.0.0dev",
 ]
 
 extras = {"tqdm": "tqdm>=4.23.0"}


### PR DESCRIPTION
This way necessary version ranges for transitive dependencies such as
google-cloud-bigquery-storage and pyarrow are included in the
installation.

Towards #329 

- [x] closes #324 
- [x] tests added / passed
- [x] passes `nox -s blacken lint`
- [x] `docs/source/changelog.rst` entry