### PR TITLE
ENH: add dtypes argument to read_gbq

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,19 @@ Changelog
 0.14.0 / TBD
 ------------
 
+- Add ``dtypes`` argument to ``read_gbq``. Use this argument to override the
+  default ``dtype`` for a particular column in the query results. For
+  example, this can be used to select nullable integer columns as the
+  ``Int64`` nullable integer pandas extension type. (:issue:`242`,
+  :issue:`332`)
+
+.. code-block:: python
+
+   df = gbq.read_gbq(
+       "SELECT CAST(NULL AS INT64) AS null_integer",
+       dtypes={"null_integer": "Int64"},
+   )
+
 Dependency updates
 ~~~~~~~~~~~~~~~~~~
 
@@ -15,7 +28,7 @@ Dependency updates
 Internal changes
 ~~~~~~~~~~~~~~~~
 
-- Update tests to run against for Python 3.8. (:issue:`331`)
+- Update tests to run against Python 3.8. (:issue:`331`)
 
 
 .. _changelog-0.13.3:

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -476,6 +476,27 @@ def test_load_does_not_modify_schema_arg(mock_bigquery_client):
     assert original_schema == original_schema_cp
 
 
+def test_read_gbq_passes_dtypes(
+    mock_bigquery_client, mock_service_account_credentials
+):
+    mock_service_account_credentials.project_id = "service_account_project_id"
+    df = gbq.read_gbq(
+        "SELECT 1 AS int_col",
+        dialect="standard",
+        credentials=mock_service_account_credentials,
+        dtypes={"int_col": "my-custom-dtype"},
+    )
+    assert df is not None
+
+    mock_list_rows = mock_bigquery_client.list_rows("dest", max_results=100)
+
+    mock_list_rows.to_dataframe.assert_called_once_with(
+        dtypes={"int_col": "my-custom-dtype"},
+        bqstorage_client=mock.ANY,
+        progress_bar_type=mock.ANY,
+    )
+
+
 def test_read_gbq_calls_tqdm(
     mock_bigquery_client, mock_service_account_credentials
 ):


### PR DESCRIPTION
Use this argument to override the default ``dtype`` for a particular column in
the query results. For example, this can be used to select nullable integer
columns as the ``Int64`` nullable integer pandas extension type.

    df = gbq.read_gbq(
        "SELECT CAST(NULL AS INT64) AS null_integer",
        dtypes={"null_integer": "Int64"},
    )

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `nox -s blacken lint`
- [x] `docs/source/changelog.rst` entry

Closes #332
Closes #242 