### PR TITLE
BUG: use object dtype for TIME columns

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 Bug fixes
 ~~~~~~~~~
 
+- Use ``object`` dtype for ``TIME`` columns. (:issue:`328`)
 - Encode floating point values with greater precision. (:issue:`326`)
 - Support ``INT64`` and other standard SQL aliases in
   :func:`~pandas_gbq.to_gbq` ``table_schema`` argument. (:issue:`322`)

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -725,7 +725,9 @@ def _bqschema_to_nullsafe_dtypes(schema_fields):
         "GEOMETRY": "object",
         "RECORD": "object",
         "STRING": "object",
-        "TIME": "datetime64[ns]",
+        # datetime.time objects cannot be case to datetime64.
+        # https://github.com/pydata/pandas-gbq/issues/328
+        "TIME": "object",
         # pandas doesn't support timezone-aware dtype in DataFrame/Series
         # constructors. It's more idiomatic to localize after construction.
         # https://github.com/pandas-dev/pandas/issues/25843


### PR DESCRIPTION
Adds tests for TIME and DATE datatypes.

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `nox -s blacken lint`
- [x] `docs/source/changelog.rst` entry

Closes #328