### PR TITLE
ENH: Enable Specifying Table Project Separately from Billing Project

### DIFF
--- a/docs/source/writing.rst
+++ b/docs/source/writing.rst
@@ -61,6 +61,22 @@ M (datetime)              TIMESTAMP
 If the data type inference does not suit your needs, supply a BigQuery schema
 as the ``table_schema`` parameter of :func:`~pandas_gbq.to_gbq`.
 
+Specifying a different billing project
+----------------------------
+
+If you want to upload to a table that is different from the project_id you
+need to run the job in, you can specify the project_id of the table as part
+of a three part identifier.
+
+
+.. code-block:: python
+
+   import pandas_gbq
+   pandas_gbq.to_gbq(
+       df, 'my_other_project.my_dataset.my_table', project_id=projectid, if_exists='fail',
+   )
+
+
 
 Troubleshooting Errors
 ----------------------

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -50,13 +50,16 @@ def encode_chunks(dataframe, chunksize=None):
 def load_chunks(
     client,
     dataframe,
+    project_id,
     dataset_id,
     table_id,
     chunksize=None,
     schema=None,
     location=None,
 ):
-    destination_table = client.dataset(dataset_id).table(table_id)
+    destination_table = client.dataset(dataset_id, project=project_id).table(
+        table_id
+    )
     job_config = bigquery.LoadJobConfig()
     job_config.write_disposition = "WRITE_APPEND"
     job_config.source_format = "CSV"

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -72,11 +72,13 @@ def tokyo_table(bigquery_client, tokyo_dataset):
 def gbq_dataset(project, credentials):
     from pandas_gbq import gbq
 
-    return gbq._Dataset(project, credentials=credentials)
+    return gbq._Dataset(project, project, credentials=credentials)
 
 
 @pytest.fixture()
 def gbq_table(project, credentials, random_dataset_id):
     from pandas_gbq import gbq
 
-    return gbq._Table(project, random_dataset_id, credentials=credentials)
+    return gbq._Table(
+        project, project, random_dataset_id, credentials=credentials
+    )

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -1565,7 +1565,7 @@ def test_create_table_data_dataset_does_not_exist(
 ):
     table_id = "test_create_table_data_dataset_does_not_exist"
     table_with_new_dataset = gbq._Table(
-        project, random_dataset_id, credentials=credentials
+        project, project, random_dataset_id, credentials=credentials
     )
     df = make_mixed_dataframe_v2(10)
     table_with_new_dataset.create(table_id, gbq._generate_bq_schema(df))

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -920,7 +920,7 @@ class TestToGBQIntegration(object):
         # put here any instruction you want to be run *BEFORE* *EVERY* test is
         # executed.
         self.table = gbq._Table(
-            project, random_dataset_id, credentials=credentials
+            project, project, random_dataset_id, credentials=credentials
         )
         self.destination_table = "{}.{}".format(random_dataset_id, TABLE_ID)
         self.credentials = credentials

--- a/tests/system/test_to_gbq.py
+++ b/tests/system/test_to_gbq.py
@@ -1,9 +1,9 @@
 import functools
 import pandas
 import pandas.testing
-
 import pytest
 
+from pandas_gbq import gbq
 
 pytest.importorskip("google.cloud.bigquery", minversion="1.24.0")
 
@@ -43,7 +43,37 @@ def test_float_round_trip(
     round_trip = bigquery_client.list_rows(table_id).to_dataframe()
     round_trip_floats = round_trip["float_col"].sort_values()
     pandas.testing.assert_series_equal(
-        round_trip_floats,
-        input_floats,
-        check_exact=True,
+        round_trip_floats, input_floats, check_exact=True
     )
+
+
+def test_include_project_name(
+    method_under_test, random_dataset_id, bigquery_client
+):
+    """Ensure that we can pass in a table identifier that includes a project."""
+
+    table_id = "{}.{}.int_round_trip".format(
+        bigquery_client.project_id, random_dataset_id
+    )
+    input_series = pandas.Series([1, 2], name="int_col")
+    df = pandas.DataFrame({"int_col": input_series})
+    method_under_test(df, table_id)
+
+    round_trip = bigquery_client.list_rows(table_id).to_dataframe()
+    round_trip_data = round_trip["int_col"].sort_values()
+    pandas.testing.assert_series_equal(
+        round_trip_data, input_series, check_exact=True
+    )
+
+
+def test_include_project_name_failure(
+    method_under_test, random_dataset_id, bigquery_client
+):
+    """Ensure that we can pass in a table identifier that includes a project."""
+    with pytest.raises(gbq.GenericGBQException):
+        table_id = "{}.{}.int_round_trip".format(
+            "this_project_does_not_exist", random_dataset_id
+        )
+        input_series = pandas.Series([1, 2], name="int_col")
+        df = pandas.DataFrame({"int_col": input_series})
+        method_under_test(df, table_id)

--- a/tests/system/test_to_gbq.py
+++ b/tests/system/test_to_gbq.py
@@ -3,7 +3,6 @@ import pandas
 import pandas.testing
 import pytest
 
-from pandas_gbq import gbq
 
 pytest.importorskip("google.cloud.bigquery", minversion="1.24.0")
 
@@ -53,7 +52,7 @@ def test_include_project_name(
     """Ensure that we can pass in a table identifier that includes a project."""
 
     table_id = "{}.{}.int_round_trip".format(
-        bigquery_client.project_id, random_dataset_id
+        bigquery_client.project, random_dataset_id
     )
     input_series = pandas.Series([1, 2], name="int_col")
     df = pandas.DataFrame({"int_col": input_series})
@@ -70,7 +69,7 @@ def test_include_project_name_failure(
     method_under_test, random_dataset_id, bigquery_client
 ):
     """Ensure that we can pass in a table identifier that includes a project."""
-    with pytest.raises(gbq.GenericGBQException):
+    with pytest.raises(Exception, match="Invalid project ID"):
         table_id = "{}.{}.int_round_trip".format(
             "this_project_does_not_exist", random_dataset_id
         )

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -374,10 +374,7 @@ def test_read_gbq_with_old_bq_raises_importerror():
         new_callable=mock.PropertyMock,
     ) as mock_version:
         mock_version.side_effect = [bigquery_version]
-        gbq.read_gbq(
-            "SELECT 1",
-            project_id="my-project",
-        )
+        gbq.read_gbq("SELECT 1", project_id="my-project")
 
 
 def test_read_gbq_with_verbose_old_pandas_no_warnings(recwarn, min_bq_version):
@@ -535,3 +532,28 @@ def test_read_gbq_calls_tqdm(
 
     _, to_dataframe_kwargs = mock_list_rows.to_dataframe.call_args
     assert to_dataframe_kwargs["progress_bar_type"] == "foobar"
+
+
+def test_extract_table():
+    project, dataset, table = gbq._process_table_id(
+        "test_project.test_dataset.test_table", "default_project"
+    )
+    assert project == "test_project"
+    assert dataset == "test_dataset"
+    assert table == "test_table"
+
+    project, dataset, table = gbq._process_table_id(
+        "test_dataset.test_table", "default_project"
+    )
+
+    assert project == "default_project"
+    assert dataset == "test_dataset"
+    assert table == "test_table"
+
+    project, dataset, table = gbq._process_table_id(
+        "`test_dataset.test_table`", "default_project"
+    )
+
+    assert project == "default_project"
+    assert dataset == "test_dataset"
+    assert table == "test_table"


### PR DESCRIPTION
This enables uploading data to a table that is not the same as the table specified for the billing project by passing in a three part identifier, such as `project.dataset.table`. References passed in with two parts `dataset.table` will still pass and default to the existing project logic. 

For our use cases, this enables us to set a billing project in context through tools such as Airflow and then have users still be able to specify independent target projects for a given data upload. 

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `nox -s blacken lint`
- [ ] `docs/source/changelog.rst` entry

Tried to avoid altering the top level API - the project specified there or in context will always be the billing project used to run jobs, and a separate table_project_id will be parsed out if the target table has a 3 part identifier. Internally, dataset + table references were updated to be able to have a decoupled billing project and location project. 

Circle-CI passes except for one test that is timing out. [Read lots of rows]. Figure there might be some adjustments, so can squash commits after changes. Also open to ideas on how to add a different project upload test - I'm not sure on how the integration tests are set up on the core repo. 

Examples:

```
pandas_gbq.to_gbq(df, '`dataset.table`', project='other_project')

pandas_gbq.to_gbq(df, 'project.dataset.table', project='other_project')

pandas_gbq.to_gbq(df, '`project`.dataset.table', project='other_project')

pandas_gbq.to_gbq(df, '`project.dataset.table`', project='other_project')
```

