### PR TITLE
ENH: add project id to destination table in to_gbq()

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+.. _changelog-0.15.0:
+
+0.15.0 / TBD
+------------
+
+Features
+~~~~~~~~
+
+- Load DataFrame with ``to_gbq`` to a table in a project different from the API
+  client project. Specify the target table ID as ``project.dataset.table`` to
+  use this feature. (:issue:`321`, :issue:`347`)
+
+
 .. _changelog-0.14.1:
 
 0.14.1 / 2020-11-10

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1147,7 +1147,7 @@ def to_gbq(
     bqclient = connector.client
 
     destination_table_ref = bigquery.table.TableReference.from_string(
-        destination_table, default_project=project_id
+        destination_table, default_project=connector.project_id
     )
 
     project_id_table = destination_table_ref.project

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -604,7 +604,7 @@ class GbqConnector(object):
     def load_data(
         self,
         dataframe,
-        destination_table,
+        destination_table_ref,
         chunksize=None,
         schema=None,
         progress_bar=True,
@@ -617,9 +617,7 @@ class GbqConnector(object):
             chunks = load.load_chunks(
                 self.client,
                 dataframe,
-                project_id_table,
-                dataset_id,
-                table_id,
+                destination_table_ref,
                 chunksize=chunksize,
                 schema=schema,
                 location=self.location,

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -604,9 +604,7 @@ class GbqConnector(object):
     def load_data(
         self,
         dataframe,
-        project_id_table,
-        dataset_id,
-        table_id,
+        destination_table,
         chunksize=None,
         schema=None,
         progress_bar=True,

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -1212,9 +1212,7 @@ def to_gbq(
 
     connector.load_data(
         dataframe,
-        project_id_table,
-        dataset_id,
-        table_id,
+        destination_table_ref,
         chunksize=chunksize,
         schema=table_schema,
         progress_bar=progress_bar,

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -50,9 +50,7 @@ def encode_chunks(dataframe, chunksize=None):
 def load_chunks(
     client,
     dataframe,
-    project_id_table,
-    dataset_id,
-    table_id,
+    destination_table,
     chunksize=None,
     schema=None,
     location=None,

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -50,13 +50,16 @@ def encode_chunks(dataframe, chunksize=None):
 def load_chunks(
     client,
     dataframe,
+    project_id_table,
     dataset_id,
     table_id,
     chunksize=None,
     schema=None,
     location=None,
 ):
-    destination_table = client.dataset(dataset_id).table(table_id)
+    destination_table = (
+        client(project=project_id_table).dataset(dataset_id).table(table_id)
+    )
     job_config = bigquery.LoadJobConfig()
     job_config.write_disposition = "WRITE_APPEND"
     job_config.source_format = "CSV"

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -57,8 +57,8 @@ def load_chunks(
     schema=None,
     location=None,
 ):
-    destination_table = (
-        client(project=project_id_table).dataset(dataset_id).table(table_id)
+    destination_table = client.dataset(dataset_id, project_id_table).table(
+        table_id
     )
     job_config = bigquery.LoadJobConfig()
     job_config.write_disposition = "WRITE_APPEND"

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -55,9 +55,6 @@ def load_chunks(
     schema=None,
     location=None,
 ):
-    destination_table = client.dataset(dataset_id, project_id_table).table(
-        table_id
-    )
     job_config = bigquery.LoadJobConfig()
     job_config.write_disposition = "WRITE_APPEND"
     job_config.source_format = "CSV"

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -50,7 +50,7 @@ def encode_chunks(dataframe, chunksize=None):
 def load_chunks(
     client,
     dataframe,
-    destination_table,
+    destination_table_ref,
     chunksize=None,
     schema=None,
     location=None,
@@ -75,7 +75,7 @@ def load_chunks(
             yield remaining_rows
             client.load_table_from_file(
                 chunk_buffer,
-                destination_table,
+                destination_table_ref,
                 job_config=job_config,
                 location=location,
             ).result()

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -257,7 +257,30 @@ def test_to_gbq_w_empty_df(mock_bigquery_client):
     mock_bigquery_client.load_table_from_file.assert_not_called()
 
 
-def test_to_gbq_w_empty_df_and_project_table(mock_bigquery_client):
+def test_to_gbq_w_default_project(mock_bigquery_client):
+    """If no project is specified, we should be able to use project from
+    default credentials.
+    """
+    import google.api_core.exceptions
+    from google.cloud.bigquery.table import TableReference
+
+    mock_bigquery_client.get_table.side_effect = (
+        google.api_core.exceptions.NotFound("my_table")
+    )
+    gbq.to_gbq(DataFrame(), "my_dataset.my_table")
+
+    mock_bigquery_client.get_table.assert_called_with(
+        TableReference.from_string("default-project.my_dataset.my_table")
+    )
+    mock_bigquery_client.create_table.assert_called_with(mock.ANY)
+    table = mock_bigquery_client.create_table.call_args[0][0]
+    assert table.project == "default-project"
+
+
+def test_to_gbq_w_project_table(mock_bigquery_client):
+    """If a project is included in the table ID, use that instead of the client
+    project. See: https://github.com/pydata/pandas-gbq/issues/321
+    """
     import google.api_core.exceptions
     from google.cloud.bigquery.table import TableReference
 
@@ -276,9 +299,6 @@ def test_to_gbq_w_empty_df_and_project_table(mock_bigquery_client):
     mock_bigquery_client.create_table.assert_called_with(mock.ANY)
     table = mock_bigquery_client.create_table.call_args[0][0]
     assert table.project == "project_table"
-
-    mock_bigquery_client.load_table_from_dataframe.assert_not_called()
-    mock_bigquery_client.load_table_from_file.assert_not_called()
 
 
 def test_to_gbq_creates_dataset(mock_bigquery_client):

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -257,6 +257,22 @@ def test_to_gbq_w_empty_df(mock_bigquery_client):
     mock_bigquery_client.load_table_from_file.assert_not_called()
 
 
+def test_to_gbq_w_empty_df_and_project_table(mock_bigquery_client):
+    import google.api_core.exceptions
+
+    mock_bigquery_client.get_table.side_effect = (
+        google.api_core.exceptions.NotFound("my_table")
+    )
+    gbq.to_gbq(
+        DataFrame(),
+        "project_table.my_dataset.my_table",
+        project_id="project_client",
+    )
+    mock_bigquery_client.create_table.assert_called_with(mock.ANY)
+    mock_bigquery_client.load_table_from_dataframe.assert_not_called()
+    mock_bigquery_client.load_table_from_file.assert_not_called()
+
+
 def test_to_gbq_creates_dataset(mock_bigquery_client):
     import google.api_core.exceptions
 

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -259,6 +259,7 @@ def test_to_gbq_w_empty_df(mock_bigquery_client):
 
 def test_to_gbq_w_empty_df_and_project_table(mock_bigquery_client):
     import google.api_core.exceptions
+    from google.cloud.bigquery.table import TableReference
 
     mock_bigquery_client.get_table.side_effect = (
         google.api_core.exceptions.NotFound("my_table")
@@ -268,7 +269,14 @@ def test_to_gbq_w_empty_df_and_project_table(mock_bigquery_client):
         "project_table.my_dataset.my_table",
         project_id="project_client",
     )
+
+    mock_bigquery_client.get_table.assert_called_with(
+        TableReference.from_string("project_table.my_dataset.my_table")
+    )
     mock_bigquery_client.create_table.assert_called_with(mock.ANY)
+    table = mock_bigquery_client.create_table.call_args[0][0]
+    assert table.project == "project_table"
+
     mock_bigquery_client.load_table_from_dataframe.assert_not_called()
     mock_bigquery_client.load_table_from_file.assert_not_called()
 


### PR DESCRIPTION
After merging this PR, it will be possible to write data into tables stored in a different project ID than the client project when calling the function `to_gbq()`.
Note that in the python-bigquery API from Google you can do this by using the method `load_table_from_dataframe` ([link](https://github.com/googleapis/python-bigquery/blob/master/google/cloud/bigquery/client.py#L1780)) which receives as input a `TableReference` object ([link](https://github.com/googleapis/python-bigquery/blob/master/google/cloud/bigquery/table.py#L119)) (with a `project_id`, a `dataset_id` and a `table_id`), being however called from a `client` running jobs in a separate `project_id`.
I think this enhancement will be very useful in situations where splitting the costs among projects is important, while maintaining the availability of the data among projects and/or departments (which is the case in some organizations).


- [x] closes #321
- [x] tests added / passed
- [x] passes `nox -s blacken lint`
- [x] `docs/source/changelog.rst` entry