### PR TITLE
FIX: exclude google-cloud-bigquery==2.4.x from dependencies

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,8 @@ Dependencies
 ~~~~~~~~~~~~
 
 - Drop support for Python 3.5 and 3.6. (:issue:`337`)
+- Drop support for `google-cloud-bigquery==2.4.*` due to query hanging bug.
+  (:issue:`343`)
 
 
 .. _changelog-0.14.1:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ INSTALL_REQUIRES = [
     "pydata-google-auth",
     "google-auth",
     "google-auth-oauthlib",
-    "google-cloud-bigquery[bqstorage,pandas]>=1.11.1,<3.0.0dev",
+    # 2.4.* has a bug where waiting for the query can hang indefinitely.
+    # https://github.com/pydata/pandas-gbq/issues/343
+    "google-cloud-bigquery[bqstorage,pandas]>=1.11.1,<3.0.0dev,!=2.4.*",
 ]
 
 extras = {"tqdm": "tqdm>=4.23.0"}


### PR DESCRIPTION
- [x] closes #xxxx
- [N/A] tests added / passed
- [x] passes `nox -s blacken lint`
- [x] `docs/source/changelog.rst` entry

Closes #343